### PR TITLE
Require ^1.0 of rollbar/rollbar-php instead of ~1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4",
         "illuminate/support": "^4.0|^5.0",
-        "rollbar/rollbar": "~1.0.0"
+        "rollbar/rollbar": "^1.0.0"
     },
     "require-dev": {
         "orchestra/testbench": "~3.0",


### PR DESCRIPTION
Version 1.1.0 of the rollbar/rollbar-php package was released less than
a month after 1.0.0 was released. As this package's current version
constraint for rollbar/rollbar-php is ~1.0.0, it isn't possible to get
the latest 1.1.x version of the rollbar-php package (which includes some
bugfixes) when this package is installed, so to allow users of this package
to get the latest version, composer.json needs updating.

As the rollbar/rollbar-php package follows semantic versioning, change
the version constraint to the more relaxed ^1.0.0, which means that
this package's composer.json doesn't need to be updated every time
there is a new 1.x release of rollbar/rollbar-php.