### PR TITLE
Don't boot rollbar if it is not configured.

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -19,6 +19,11 @@ class RollbarServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // Don't boot rollbar if it is not configured.
+        if (! getenv('ROLLBAR_TOKEN') and ! $this->app['config']->get('services.rollbar')) {
+            return;
+        }
+
         $app = $this->app;
 
         // Listen to log messages.


### PR DESCRIPTION
When rollbar is **NOT** configured, it's services isn't registered, but it's invoked whenever there's an exception in the application since it's still booted and always listen to log events, and thus we get the following exception (this PR avoids that exception):
```
(1/1) BindingResolutionException
Unresolvable dependency resolving [Parameter #0 [ <required> array $config ]] in class Rollbar\RollbarLogger
```

Exception stack:
```
in Container.php (line 933)
at Container->unresolvablePrimitive(object(ReflectionParameter))
in Container.php (line 871)
at Container->resolvePrimitive(object(ReflectionParameter))
in Container.php (line 812)
at Container->resolveDependencies(array(object(ReflectionParameter)))
in Container.php (line 779)
at Container->build('Rollbar\\RollbarLogger')
in Container.php (line 631)
at Container->resolve('Rollbar\\RollbarLogger', array())
in Container.php (line 586)
at Container->make('Rollbar\\RollbarLogger', array())
in Application.php (line 721)
at Application->make('Rollbar\\RollbarLogger')
in Container.php (line 885)
at Container->resolveClass(object(ReflectionParameter))
in Container.php (line 813)
at Container->resolveDependencies(array(object(ReflectionParameter), object(ReflectionParameter), object(ReflectionParameter)))
in Container.php (line 779)
at Container->build('Rollbar\\Laravel\\RollbarLogHandler')
in Container.php (line 631)
at Container->resolve('Rollbar\\Laravel\\RollbarLogHandler', array())
in Container.php (line 586)
at Container->make('Rollbar\\Laravel\\RollbarLogHandler', array())
in Application.php (line 721)
at Application->make('Rollbar\\Laravel\\RollbarLogHandler')
in Container.php (line 1195)
at Container->offsetGet('Rollbar\\Laravel\\RollbarLogHandler')
in RollbarServiceProvider.php (line 39)
at RollbarServiceProvider->Rollbar\Laravel\{closure}(object(MessageLogged))
in Dispatcher.php (line 349)
at Dispatcher->Illuminate\Events\{closure}('Illuminate\\Log\\Events\\MessageLogged', array(object(MessageLogged)))
in Dispatcher.php (line 200)
at Dispatcher->dispatch('Illuminate\\Log\\Events\\MessageLogged')
in Writer.php (line 295)
at Writer->fireLogEvent('error', 'Unresolvable dependency resolving [Parameter #0 [ <required> array $config ]] in class Rollbar\\RollbarLogger', array('exception' => object(BindingResolutionException)))
in Writer.php (line 201)
at Writer->writeLog('error', 'Unresolvable dependency resolving [Parameter #0 [ <required> array $config ]] in class Rollbar\\RollbarLogger', array('exception' => object(BindingResolutionException)))
in Writer.php (line 114)
at Writer->error('Unresolvable dependency resolving [Parameter #0 [ <required> array $config ]] in class Rollbar\\RollbarLogger', array('exception' => object(BindingResolutionException)))
in Handler.php (line 112)
at Handler->report(object(BindingResolutionException))
in Handler.php (line 37)
at Handler->report(object(BindingResolutionException))
in HandleExceptions.php (line 81)
at HandleExceptions->handleException(object(BindingResolutionException))
```