### PR TITLE
Fix person_fn not being called when session not empty

### DIFF
--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -177,4 +177,27 @@ class RollbarTest extends \Orchestra\Testbench\TestCase
         $this->app->log->alert('hello');
         $this->app->log->emergency('hello');
     }
+
+    public function testPersonFunctionIsCalledWhenSessionContainsAtLeastOneItem()
+    {
+        $this->app->config->set('services.rollbar.person_fn', function () {
+            return [
+                'id' => '123',
+                'username' => 'joebloggs',
+            ];
+        });
+
+        $logger = $this->app->make('Rollbar\RollbarLogger');
+
+        $this->app->session->put('foo', 'bar');
+
+        $this->app->log->debug('hello');
+
+        $config = $logger->extend([]);
+
+        $person = $config['person'];
+
+        $this->assertEquals('123', $person['id']);
+        $this->assertEquals('joebloggs', $person['username']);
+    }
 }


### PR DESCRIPTION
This PR fixes the broken `person_fn` as reported in #1 and #3, but
as they seem pretty old inactive PRs with broken tests, I thought I'd
submit a new one that can hopefully be merged soon, as this bug is
stopping us from upgrading to the newer versions of this library.

I decided to go for the safest option, which is to revert to the old existing
logic when `person_fn` still worked.

### Explanation

Currently, when the session is not empty, this package always sets a
`person` entry in the rollbar config, which results in the rollbar/rollbar
package never caling the `person_fn`.

The rollbar/rollbar package only calls `$config['person_fn']` when the
`$config['person']` doesn't already exist, which as stated above, will
always be set when the session is not empty.

Revert back to the behaviour originally found in RollbarLogHandler before
it was refactored in 8988c22 which introduced this bug. As it previously used
an older version of the rollbar/rollbar library, this commit doesn't revert the
changes back exactly, but is the equivalent changes for the latest version
of the rollbar/rollbar library API.

Add a regression test that currently fails on master branch but passes
with these canges to `RollbarLogHandler`.