### PR TITLE
Check the correct token to ensure if we need to register

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -91,7 +91,7 @@ class RollbarServiceProvider extends ServiceProvider
     public function stop()
     {
         $level = getenv('ROLLBAR_LEVEL') ?: $this->app->config->get('services.rollbar.level', null);
-        $token = getenv('ROLLBAR_TOKEN') ?: $this->app->config->get('services.rollbar.token', null);
+        $token = getenv('ROLLBAR_TOKEN') ?: $this->app->config->get('services.rollbar.access_token', null);
         $hasToken = empty($token) === false;
 
         return $hasToken === false || $level === 'none';


### PR DESCRIPTION
In the boot method, we check for the `access_token` variable, but when checking when to register or not we're checking for the `token` variable. This ensures the same variable is checked.