### PR TITLE
Fixed the access_token config getter function.

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -66,7 +66,7 @@ class RollbarServiceProvider extends ServiceProvider
     {
         $level = static::config('level');
 
-        $token = static::config('token');
+        $token = static::config('access_token');
 
         $hasToken = empty($token) === false;
 
@@ -86,10 +86,6 @@ class RollbarServiceProvider extends ServiceProvider
 
         if ($envKey === 'ROLLBAR_ACCESS_TOKEN') {
             $envKey = 'ROLLBAR_TOKEN';
-        }
-
-        if ($key === 'token') {
-            $key = 'access_token';
         }
 
         $logKey = empty($key) ? 'logging.channels.rollbar' : "logging.channels.rollbar.$key";

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -88,6 +88,10 @@ class RollbarServiceProvider extends ServiceProvider
             $envKey = 'ROLLBAR_TOKEN';
         }
 
+        if ($key === 'token') {
+            $key = 'access_token';
+        }
+
         $logKey = empty($key) ? 'logging.channels.rollbar' : "logging.channels.rollbar.$key";
 
         return getenv($envKey) ?: Config::get($logKey, $default);


### PR DESCRIPTION
As per the official documentation, the parameter for the token on the logging config file should be called `access_token`. However, without this fix, you need to have both `access_token` and `token` set to the same value, under `logging.channels.rollbar`. Otherwise, it will not work.

This adds another hotfix to replace the `$key`, when its value is `"token"`, with `"access_token"`.

P.S. As an alternative, you could also replace the line: `$token = static::config('token');` with `$token = static::config('access_token');`, just so we don't add another if. I'll leave the authors to decide which is best.

----

Later edit: I went ahead and created a new commit to remove the extra if and fix the actual bug. But feel free to use either of the versions.