### PR TITLE
changed monolog handler to extend non-deprecated class

### DIFF
--- a/src/MonologHandler.php
+++ b/src/MonologHandler.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar\Laravel;
 
-use Rollbar\Monolog\Handler\RollbarHandler;
+use Monolog\Handler\RollbarHandler;
 
 class MonologHandler extends RollbarHandler
 {


### PR DESCRIPTION
The Rollbar handler class has the following message 
```
/*
 * !!! DEPRECATED AS OF 8/4/2018 !!!
 * 
 * Please, do not use this class anymore to use Rollbar with Monolog anymore.
 * The Monolog library includes a dedicated handler now here:
 * https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/RollbarHandler.php
 *
 * Using Monolog's handler is the recommended approach when using Rollbar
 * with Monolog.
 */
```

Despite that message being included, the `MonologHandler` class was still extending this class. I just modified line 5 in that class from 
```
use Rollbar\Monolog\Handler\RollbarHandler;
```
to 
```
use Monolog\Handler\RollbarHandler;
```

Which is where the new RollbarHandler class is located. Running the tests shows it doesn't affect any current functionality, and if the RollbarHandler class is updated via monolog, people who use this package shouldn't have to wait for the updates to reflect in this package.

Unrelated to this PR: while the note was made in the class, a deprecation warning might be nice for anyone who might be extending that class directly from the Rollbar package and not from Monolog.