### PR TITLE
Added fallback on getKey method.

### DIFF
--- a/src/MonologHandler.php
+++ b/src/MonologHandler.php
@@ -42,8 +42,13 @@ class MonologHandler extends RollbarHandler
             $data = @call_user_func($config['person_fn']);
             if (! empty($data)) {
                 if (is_object($data)) {
-                    if (method_exists($data, 'getKey')) {
+                    if (isset($data->id)) {
+                        $person['id'] = $data->id;
+                    } elseif (method_exists($data, 'getKey')) {
                         $person['id'] = $data->getKey();
+                    }
+                    
+                    if (isset($person['id'])) {
                         if (isset($data->username)) {
                             $person['username'] = $data->username;
                         }

--- a/src/MonologHandler.php
+++ b/src/MonologHandler.php
@@ -42,8 +42,8 @@ class MonologHandler extends RollbarHandler
             $data = @call_user_func($config['person_fn']);
             if (! empty($data)) {
                 if (is_object($data)) {
-                    if (isset($data->id)) {
-                        $person['id'] = $data->id;
+                    if (method_exists($data, 'getKey')) {
+                        $person['id'] = $data->getKey();
                         if (isset($data->username)) {
                             $person['username'] = $data->username;
                         }


### PR DESCRIPTION
Hello,

I just implemented this package into my project and my primary key is not `id`, so this means the `person_fn` key in the config will not work for me because it looks at the `id` attribute. 
So I added a fallback on the function of Laravel: `getKey()`, this will look at if the `$primaryKey` name is changed inside the modal else will send the value from the `id` attribute.  

If you have any question feel free to ask.