### PR TITLE
Fixed MonologHandler conflict while using rollbar agent

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -42,6 +42,7 @@ class RollbarServiceProvider extends ServiceProvider
             $handleError = (bool) Arr::pull($config, 'handle_error');
             $handleFatal = (bool) Arr::pull($config, 'handle_fatal');
 
+            $config['handler'] = $config['rollbar_handler'] ?? null;
             Rollbar::init($config, $handleException, $handleError, $handleFatal);
 
             return Rollbar::logger();


### PR DESCRIPTION
## Description of the change

Resolver handler conflict while using rollbar agent handler. [Bug which was describer here](https://github.com/rollbar/rollbar-php-laravel/issues/85)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Bug [#85 ](https://github.com/rollbar/rollbar-php-laravel/issues/85) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
