### PR TITLE
Add support for rollbar-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 .DS_Store
+.phpunit.result.cache

--- a/src/AgentHandler.php
+++ b/src/AgentHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rollbar\Laravel;
+
+/**
+ * Adaptor for [rollbar-agent][1] in Laravel logging configuration.
+ *
+ * The configuration for logging in Laravel requires an instance of
+ * [`Monolog\Handler\HandlerInterface`][2], but the Rollbar library requires
+ * a string with value of "agent" to use the agent.
+ *
+ * This class carries the HandlerInterface requirement to satisfy the Laravel
+ * logging configuration and is recognized in the ServiceProvider, which
+ * converts it to the appropriate agent configuration just in time.
+ *
+ * This issue was raised by [Issue 85][3].
+ *
+ * [1]:https://github.com/rollbar/rollbar-agent
+ * [2]:https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/HandlerInterface.php
+ * [3]:https://github.com/rollbar/rollbar-php-laravel/issues/85
+ */
+class AgentHandler extends MonologHandler
+{
+}

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -42,6 +42,12 @@ class RollbarServiceProvider extends ServiceProvider
             $handleError = (bool) Arr::pull($config, 'handle_error');
             $handleFatal = (bool) Arr::pull($config, 'handle_fatal');
 
+            // Convert a request for the Rollbar agent to handle the logs to
+            // the format expected by `Rollbar::init`.
+            // @see https://github.com/rollbar/rollbar-php-laravel/issues/85
+            if ($config['handler'] instanceof AgentHandler) {
+                $config['handler'] = 'agent';
+            }
             Rollbar::init($config, $handleException, $handleError, $handleFatal);
 
             return Rollbar::logger();

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -45,8 +45,8 @@ class RollbarServiceProvider extends ServiceProvider
             // Convert a request for the Rollbar agent to handle the logs to
             // the format expected by `Rollbar::init`.
             // @see https://github.com/rollbar/rollbar-php-laravel/issues/85
-            $handler = Arr::pull($config, 'handler');
-            if ($handler instanceof AgentHandler) {
+            $handler = Arr::get($config, 'handler');
+            if ($handler === AgentHandler::class) {
                 $config['handler'] = 'agent';
             }
             Rollbar::init($config, $handleException, $handleError, $handleFatal);

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -45,7 +45,8 @@ class RollbarServiceProvider extends ServiceProvider
             // Convert a request for the Rollbar agent to handle the logs to
             // the format expected by `Rollbar::init`.
             // @see https://github.com/rollbar/rollbar-php-laravel/issues/85
-            if ($config['handler'] instanceof AgentHandler) {
+            $handler = Arr::pull($config, 'handler');
+            if ($handler instanceof AgentHandler) {
                 $config['handler'] = 'agent';
             }
             Rollbar::init($config, $handleException, $handleError, $handleFatal);

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -4,6 +4,7 @@ namespace Rollbar\Laravel\Tests;
 
 use Rollbar\Laravel\RollbarServiceProvider;
 use Rollbar\Laravel\MonologHandler;
+use Rollbar\Laravel\AgentHandler;
 use Rollbar\RollbarLogger;
 use Monolog\Logger;
 use Mockery;
@@ -32,6 +33,9 @@ class RollbarTest extends \Orchestra\Testbench\TestCase
 
         $handler = $this->app->make(MonologHandler::class);
         $this->assertInstanceOf(MonologHandler::class, $handler);
+
+        $handler = $this->app->make(AgentHandler::class);
+        $this->assertInstanceOf(AgentHandler::class, $handler);
     }
 
     public function testIsSingleton()
@@ -60,6 +64,21 @@ class RollbarTest extends \Orchestra\Testbench\TestCase
         $this->assertEquals('staging', $config['environment']);
         $this->assertEquals('/tmp', $config['root']);
         $this->assertEquals(E_ERROR, $config['included_errno']);
+    }
+
+    public function testRollbarAgentConfigurationAdapter()
+    {
+        $handler = Mockery::mock(AgentHandler::class);
+        $this->app->config->set('logging.channels.rollbar.handler', $handler);
+
+        $client = $this->app->make(RollbarLogger::class);
+        $config = $client->extend([]);
+
+        $this->assertEquals(
+            'agent',
+            $config['handler'],
+            'AgentHandler given as Laravel logging config handler should be given as "agent" to Rollbar::init'
+        );
     }
 
     // public function testAutomaticContext()

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -68,8 +68,7 @@ class RollbarTest extends \Orchestra\Testbench\TestCase
 
     public function testRollbarAgentConfigurationAdapter()
     {
-        $handler = Mockery::mock(AgentHandler::class);
-        $this->app->config->set('logging.channels.rollbar.handler', $handler);
+        $this->app->config->set('logging.channels.rollbar.handler', AgentHandler::class);
 
         $client = $this->app->make(RollbarLogger::class);
         $config = $client->extend([]);


### PR DESCRIPTION
## Description of the change

The configuration for logging in Laravel requires an instance of [`Monolog\Handler\HandlerInterface`][1], but the Rollbar library requires a string with value of "agent" to use the agent. This disconnect makes it impossible to use the Rollbar agent with Laravel.

Fixes Issue #85, by way of an adapter class. An example Laravel configuration to use the adapter:

```
'rollbar' => [
      'driver' => 'monolog',
      'handler' => \Rollbar\Laravel\AgentHandler::class,
      'level' => 'debug',
      'access_token' => env('ROLLBAR_TOKEN'),
      'environment' => 'production'
],
```

[1]:https://github.com/Seldaek/monolog/blob/main/src/Monolog/Handler/HandlerInterface.php

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fixes Issue #85. 

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
