### PR TITLE
feat: add Laravel integration test matrix

### DIFF
--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -10,18 +10,22 @@
 #   act -P ubuntu-latest=shivammathur/node:latest
 #
 # @see https://github.com/nektos/act/issues/329
-name: Rollbar-PHP-Laravel CI, master
+name: Rollbar-PHP-Laravel CI, version 2.x
 
-# Fire this action on pushes to main branch (master) as well as other branches
-# or pull requests, excluding those in the next/ lineage. Also, run every day
-# at 02:42 GMT -- this catches failures from transitive dependencies.
+# Fire this action on pushes to 2.x legacy branches (the official one, as well
+# as development branches within it -- hence the wildcard), and also tags for
+# the legacy lineage. Also, run every day at 02:42 GMT to catch failures from
+# transitive dependencies.
+
 on:
   push:
-    branches-ignore:
-      - next/**
+    branches:
+      - next/2.x/**
+    tags:
+      - v2.*
   pull_request:
-    branches-ignore:
-      - next/**
+    branches:
+      - next/2.x/**
   schedule:
     - cron: '42 2 * * *'
 
@@ -31,25 +35,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2]
-        laravel: [^8, ^7, ^6]
-        exclude:
-          # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
-          - laravel: ^8
-            php: 7.2
-          - laravel: ^8
-            php: 7.1
-          - laravel: ^8
-            php: 7.0
-          # Laravel 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
-          - laravel: ^7
-            php: 7.1
-          - laravel: ^7
-            php: 7.0
-          - laravel: ^6
-            php: 7.1
-          - laravel: ^6
-            php: 7.0
+        php: [7.4, 7.3, 7.2, 7.1, 7.0]
+        laravel: [^5.5]
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})

--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -42,6 +42,9 @@ jobs:
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
       - name: Install PHP and composer environment
         uses: shivammathur/setup-php@v2
         with:
@@ -50,9 +53,6 @@ jobs:
 
       - name: Create Laravel test app
         run: composer create-project laravel/laravel rollbar-test-app ${{ matrix.laravel }}
-
-      - name: Checkout the code
-        uses: actions/checkout@v2
 
       - name: Install that code using Composer rigged to look in the parent directory
         working-directory: rollbar-test-app

--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -42,6 +42,9 @@ jobs:
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
       - name: Install PHP and composer environment
         uses: shivammathur/setup-php@v2
         with:
@@ -50,9 +53,6 @@ jobs:
 
       - name: Create Laravel test app
         run: composer create-project laravel/laravel rollbar-test-app ${{ matrix.laravel }}
-
-      - name: Checkout the code
-        uses: actions/checkout@v2
 
       - name: Install that code using Composer rigged to look in the parent directory
         working-directory: rollbar-test-app

--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -10,18 +10,22 @@
 #   act -P ubuntu-latest=shivammathur/node:latest
 #
 # @see https://github.com/nektos/act/issues/329
-name: Rollbar-PHP-Laravel CI, master
+name: Rollbar-PHP-Laravel CI, version 4.x
 
-# Fire this action on pushes to main branch (master) as well as other branches
-# or pull requests, excluding those in the next/ lineage. Also, run every day
-# at 02:42 GMT -- this catches failures from transitive dependencies.
+# Fire this action on pushes to 4.x legacy branches (the official one, as well
+# as development branches within it -- hence the wildcard), and also tags for
+# the legacy lineage. Also, run every day at 02:42 GMT to catch failures from
+# transitive dependencies.
+
 on:
   push:
-    branches-ignore:
-      - next/**
+    branches:
+      - next/4.x/**
+    tags:
+      - v4.*
   pull_request:
-    branches-ignore:
-      - next/**
+    branches:
+      - next/4.x/**
   schedule:
     - cron: '42 2 * * *'
 
@@ -31,25 +35,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2]
-        laravel: [^8, ^7, ^6]
-        exclude:
-          # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
-          - laravel: ^8
-            php: 7.2
-          - laravel: ^8
-            php: 7.1
-          - laravel: ^8
-            php: 7.0
-          # Laravel 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
-          - laravel: ^7
-            php: 7.1
-          - laravel: ^7
-            php: 7.0
-          - laravel: ^6
-            php: 7.1
-          - laravel: ^6
-            php: 7.0
+        php: [7.4, 7.3, 7.2, 7.1]
+        laravel: [^5.8, ^5.7, ^5.6]
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
+          composer require rollbar/rollbar-laravel
           echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
           echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
           chmod 400 .env
@@ -65,6 +66,7 @@ jobs:
                   "handler" => \Rollbar\Laravel\MonologHandler::class,
                   "access_token" => env("ROLLBAR_TOKEN"),
                   "level" => "debug",
+                  // use the check_ignore filter to capture log messages for verification
                   "check_ignore" => "check_ignore",
                 )
               )
@@ -83,8 +85,10 @@ jobs:
               return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
             }
             function check_ignore($isUncaught, $toLog, $payload) {
+              // write log message to a file for inspection
               file_put_contents(temp_file(), (string)$toLog);
-              return false;
+              // return indication that the log should be dropped
+              return true;
             }
           '
 
@@ -96,8 +100,13 @@ jobs:
             class LoggingTest extends \Tests\TestCase {
               public function test_log_call_invokes_rollbar_check_ignore()
               {
-                $value = env("GITHUB_RUN_ID");
+                // generate a random valued log message to check it is passed through the
+                // Laravel logging mechanism into Rollbar
+                $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
+
                 \Log::error($value);
+
+                // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),
                   "Rollbar check_ignore handler not invoked, suggesting an issue integrating Rollbar into Laravel.");
                 $this->assertSame($value, file_get_contents(temp_file()),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1, 7.0]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
-        rollbar-php-laravel: [^7, 4.*, 2.*]
+        php: [7.4, 7.3, 7.2, 7.1]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        rollbar-php-laravel: [^7, 4.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]
@@ -140,14 +140,11 @@ jobs:
         run: |
           > app/helpers.php echo '<?php
             function temp_file() {
-              $x = env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
-              var_dump($x);
-              return $x;
+              return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
             }
             function check_ignore($isUncaught, $toLog, $payload) {
               // write log message to a file for inspection
               $ok = file_put_contents(temp_file(), (string)$toLog);
-              var_dump($ok);
               // return indication that the log should be dropped
               return true;
             }
@@ -165,9 +162,7 @@ jobs:
                 // Laravel logging mechanism into Rollbar
                 $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
 
-                var_dump("x");
                 \Log::error($value);
-                var_dump("y");
 
                 // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
-        rollbar-php-laravel: [^7, 4.*]
+        php: [7.4]
+        laravel: [^8]
+        rollbar-php-laravel: [^7]
+        #simplify#php: [7.4, 7.3, 7.2, 7.1]
+        #simplify#laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        #simplify#rollbar-php-laravel: [^7, 4.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: Rollbar-PHP-Laravel CI
 
 # Fire this action on pushes to main branch (master) as well as other branches
 # or pull requests. Also, run every day at 02:42 GMT -- this catches failures
-# from dependencies that update indepdently.
+# from dependencies that update independently.
 on:
   push:
   pull_request:
@@ -17,21 +17,17 @@ on:
     - cron: '42 2 * * *'
 
 jobs:
-  # Check that this runs on PHP on all versions we claim to support, on both
-  # UNIX-like and Windows environments, and that use both the lowest possible
-  # compatible version as well as the most-recent stable version. This will
-  # fail-fast by default, so we include our edgiest versions (currently 7.4)
-  # first as they're most likely to fail.
-  # @seealso https://freek.dev/1546
-  # @seealso https://www.dereuromark.de/2019/01/04/test-composer-dependencies-with-prefer-lowest/
-  php-tests:
+  # Check that this runs on all combinations of Laravel we claim to support.
+  laravel-tests:
     strategy:
       matrix:
-        php: [7.3, 7.2]
-        dependency: [stable]
         os: [ubuntu]
-
-    name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
+        php: [7.4]
+        laravel: [^7.0]
+        rollbar-php-laravel: [^7.0]
+    env:
+      ROLLBAR_TOKEN: ad865e76e7fb496fab096ac07b1dbabb
+    name: Laravel ${{ matrix.laravel }} PHP ${{ matrix.php }} ${{ matrix.os }} Rollbar ${{ matrix.rollbar-php }}
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout the code
@@ -42,29 +38,70 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl
-          ini-values: ${{ matrix.ini }}
-          coverage: xdebug
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Create Laravel test app
+        run: composer create-project laravel/laravel rollbar-test-app
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}-${{ matrix.dependency }}-
-          restore-keys: ${{ matrix.os }}-composer-${{ matrix.dependency }}-
+      - name: Install rollbar-php-laravel package
+        working-directory: rollbar-test-app
+        run: |
+          echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
+          echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
+          chmod 400 .env
 
-      - name: Install dependencies
-        run: composer update --prefer-${{ matrix.dependency }} --prefer-dist --no-interaction
+      - name: Configure Laravel to use Rollbar and configure Rollbar to invoke logging callback
+        working-directory: rollbar-test-app
+        run: |
+          > config/logging.php echo '<?php return array (
+              "default" => "rollbar",
+              "channels" => array (
+                "rollbar" => array (
+                  "driver" => "monolog",
+                  "handler" => \Rollbar\Laravel\MonologHandler::class,
+                  "access_token" => env("ROLLBAR_TOKEN"),
+                  "level" => "debug",
+                  "check_ignore" => "check_ignore",
+                )
+              )
+            );
+          '
+          touch app/helpers.php
+          > tmp-composer.json jq '.autoload += { "files": [ "app/helpers.php" ] }' composer.json
+          mv tmp-composer.json composer.json
+          composer dump-autoload
 
-      - name: Make logs directory
-        run: mkdir -p build/logs
+      - name: Define logging callback that invokes when Laravel logs through Rollbar
+        working-directory: rollbar-test-app
+        run: |
+          > app/helpers.php echo '<?php
+            function temp_file() {
+              return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
+            }
+            function check_ignore($isUncaught, $toLog, $payload) {
+              file_put_contents(temp_file(), (string)$toLog);
+              return false;
+            }
+          '
 
-      - name: Execute tests
-        run: composer test
+      - name: Define Laravel tests to exercise and verify logging
+        working-directory: rollbar-test-app
+        run: |
+          > tests/Feature/LoggingTest.php echo '<?php
+            namespace Tests\Feature;
+            class LoggingTest extends \Tests\TestCase {
+              public function test_log_call_invokes_rollbar_check_ignore()
+              {
+                $value = env("GITHUB_RUN_ID");
+                \Log::error($value);
+                $this->assertFileExists(temp_file(),
+                  "Rollbar check_ignore handler not invoked, suggesting an issue integrating Rollbar into Laravel.");
+                $this->assertSame($value, file_get_contents(temp_file()),
+                  "check_ignore file did not contain expected value, suggesting file left by another process.");
+              }
+            }
+          '
 
-      - name: Report results
-        if: success()
-        run: ./vendor/bin/php-coveralls -v || true
+      - name: Invoke the Laravel test suite
+        working-directory: rollbar-test-app
+        run: |
+          ./vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         laravel: [^7.0]
         rollbar-php-laravel: [^7.0]
     env:
-      ROLLBAR_TOKEN: ad865e76e7fb496fab096ac07b1dbabb
+      ROLLBAR_TOKEN: 00000000000000000000000000000000
     name: Laravel ${{ matrix.laravel }} PHP ${{ matrix.php }} ${{ matrix.os }} Rollbar ${{ matrix.rollbar-php }}
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu]
         php: [7.4, 7.3, 7.2, 7.1, 7.0]
         laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
-        rollbar-php-laravel: [^7, ^4, ^2]
+        rollbar-php-laravel: [^7, 4.*, 2.*]
         exclude:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8
@@ -49,35 +49,35 @@ jobs:
             php: 7.0
           # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
           - laravel: ^6
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
           - laravel: ^6
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^7
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
           - laravel: ^7
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^8
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
           - laravel: ^8
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           # Laravel 5.6 to 5.8 use rollbar-php-laravel 4.x, so exclude all above that and below that
           - laravel: ^5.6
             rollbar-php-laravel: ^7
           - laravel: ^5.6
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^5.7
             rollbar-php-laravel: ^7
           - laravel: ^5.7
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^5.8
             rollbar-php-laravel: ^7
           - laravel: ^5.8
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           # Laravel 5.5 and below use rollbar-php-laravel 2.x, so exclude all above that
           - laravel: ^5.5
             rollbar-php-laravel: ^7
           - laravel: ^5.5
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
     env:
       ROLLBAR_TOKEN: 00000000000000000000000000000000
     name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
@@ -98,7 +98,7 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
-          composer require rollbar/rollbar-laravel:${{ matrix.rollbar-php-laravel }}
+          composer require rollbar/rollbar-laravel ${{ matrix.rollbar-php-laravel }}
           echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
           echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
           chmod 400 .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             rollbar-php-laravel: 4.*
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
-    name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
+    name: Laravel ${{ matrix.laravel }}/Rollbar ${{ matrix.rollbar-php-laravel }}/PHP ${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout the code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,6 @@ jobs:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8
             php: 7.2
-          - laravel: ^8
-            php: 7.1
-          - laravel: ^8
-            php: 7.0
-          # Laravel 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
-          - laravel: ^7
-            php: 7.1
-          - laravel: ^7
-            php: 7.0
-          - laravel: ^6
-            php: 7.1
-          - laravel: ^6
-            php: 7.0
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4]
-        laravel: [^8]
-        rollbar-php-laravel: [^7]
+        php: [7.4, 7.3, 7.2, 7.1]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        rollbar-php-laravel: [^7, 4.*]
+        #fails#php: [7.0]
+        #fails#laravel: [^5.5]
+        #fails#rollbar-php-laravel: [2.*]
         exclude:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,60 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4]
-        laravel: [^7.0]
-        rollbar-php-laravel: [^7.0]
+        php: [7.4, 7.3, 7.2, 7.1, 7.0]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
+        rollbar-php-laravel: [^7, ^4, ^2]
+        exclude:
+          # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
+          - laravel: ^8
+            php: 7.2
+          - laravel: ^8
+            php: 7.1
+          - laravel: ^8
+            php: 7.0
+          # Laravel 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
+          - laravel: ^7
+            php: 7.1
+          - laravel: ^7
+            php: 7.0
+          - laravel: ^6
+            php: 7.1
+          - laravel: ^6
+            php: 7.0
+          # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
+          - laravel: ^6
+            rollbar-php-laravel: ^4
+          - laravel: ^6
+            rollbar-php-laravel: ^2
+          - laravel: ^7
+            rollbar-php-laravel: ^4
+          - laravel: ^7
+            rollbar-php-laravel: ^2
+          - laravel: ^8
+            rollbar-php-laravel: ^4
+          - laravel: ^8
+            rollbar-php-laravel: ^2
+          # Laravel 5.6 to 5.8 use rollbar-php-laravel 4.x, so exclude all above that and below that
+          - laravel: ^5.6
+            rollbar-php-laravel: ^7
+          - laravel: ^5.6
+            rollbar-php-laravel: ^2
+          - laravel: ^5.7
+            rollbar-php-laravel: ^7
+          - laravel: ^5.7
+            rollbar-php-laravel: ^2
+          - laravel: ^5.8
+            rollbar-php-laravel: ^7
+          - laravel: ^5.8
+            rollbar-php-laravel: ^2
+          # Laravel 5.5 and below use rollbar-php-laravel 2.x, so exclude all above that
+          - laravel: ^5.5
+            rollbar-php-laravel: ^7
+          - laravel: ^5.5
+            rollbar-php-laravel: ^4
     env:
       ROLLBAR_TOKEN: 00000000000000000000000000000000
-    name: Laravel ${{ matrix.laravel }} PHP ${{ matrix.php }} ${{ matrix.os }} Rollbar ${{ matrix.rollbar-php }}
+    name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout the code
@@ -50,7 +98,7 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
-          composer require rollbar/rollbar-laravel
+          composer require rollbar/rollbar-laravel:${{ matrix.rollbar-php-laravel }}
           echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
           echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
           chmod 400 .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
       - name: Install PHP and composer environment
         uses: shivammathur/setup-php@v2
         with:
@@ -50,9 +53,6 @@ jobs:
 
       - name: Create Laravel test app
         run: composer create-project laravel/laravel rollbar-test-app ${{ matrix.laravel }}
-
-      - name: Checkout the code
-        uses: actions/checkout@v2
 
       - name: Install that code using Composer rigged to look in the parent directory
         working-directory: rollbar-test-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           - laravel: ^5.5
             rollbar-php-laravel: 4.*
     env:
-      ROLLBAR_TOKEN: 00000000000000000000000000000000
+      ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
-        rollbar-php-laravel: [^7, 4.*]
+        php: [7.4, 7.3, 7.2, 7.1, 7.0]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
+        rollbar-php-laravel: [^7, 4.*, 2.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           extensions: curl
 
       - name: Create Laravel test app
-        run: composer create-project laravel/laravel rollbar-test-app
+        run: composer create-project laravel/laravel rollbar-test-app ${{ matrix.laravel }}
 
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
 # Primary CI checks for Rollbar-PHP-Laravel.
+# We're checking that logging within Laravel passes through the Rollbar Laravel
+# integration when that integration is properly installed. We make this check
+# for all supported combinations of Laravel, Rollbar, and PHP. We are not
+# checking that messages are properly sent to Rollbar: that's handled by
+# rollbar-php.
 #
 # Test with act:
 #   brew install act

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
         run: |
           > app/helpers.php echo '<?php
             function temp_file() {
-              return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
+              $x = env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
+              var_dump($x);
+              return $x;
             }
             function check_ignore($isUncaught, $toLog, $payload) {
               // write log message to a file for inspection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,8 @@ jobs:
             }
             function check_ignore($isUncaught, $toLog, $payload) {
               // write log message to a file for inspection
-              file_put_contents(temp_file(), (string)$toLog);
+              $ok = file_put_contents(temp_file(), (string)$toLog);
+              var_dump($ok);
               // return indication that the log should be dropped
               return true;
             }
@@ -167,7 +168,9 @@ jobs:
                 // Laravel logging mechanism into Rollbar
                 $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
 
+                var_dump("x");
                 \Log::error($value);
+                var_dump("y");
 
                 // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4]
-        laravel: [^8]
-        rollbar-php-laravel: [^7]
-        #simplify#php: [7.4, 7.3, 7.2, 7.1]
-        #simplify#laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
-        #simplify#rollbar-php-laravel: [^7, 4.*]
+        php: [7.4, 7.3, 7.2, 7.1]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        rollbar-php-laravel: [^7, 4.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
     name: Laravel ${{ matrix.laravel }}/Rollbar ${{ matrix.rollbar-php-laravel }}/PHP ${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
+      # Note: this step is currently unused, because we are installing Rollbar
+      # Note: from Packagist 3 steps later. This was done to prove out currently
+      # Note: working combinations from published versions. The next iteration
+      # Note: will move the CI to use the correct branch, so that pre-published
+      # Note: code will be tested.
       - name: Checkout the code
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1, 7.0]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
-        rollbar-php-laravel: [^7, 4.*, 2.*]
+        php: [7.4]
+        laravel: [^8]
+        rollbar-php-laravel: [^7]
         exclude:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8
@@ -46,6 +46,13 @@ jobs:
           - laravel: ^6
             php: 7.1
           - laravel: ^6
+            php: 7.0
+          # Laravel 5.8, 5.7, and 5.6 requires php 7.1.3+, so exclude all PHP versions prior to 7.1.3 for them
+          - laravel: ^5.8
+            php: 7.0
+          - laravel: ^5.7
+            php: 7.0
+          - laravel: ^5.6
             php: 7.0
           # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
           - laravel: ^6


### PR DESCRIPTION
## Description of the change

We integrate with Laravel versions 5.5+. The existing tests verify unit functionality with [TestBench][1] but has a few caveats. First, it tests the package against the latest version of Laravel on the PHP engine running the test. Second, as written, there was no version constraint for testbench 3, which is the only way to get Laravel 5 tests. Third, the tests do not perform an end to end test of actual logging within a Laravel application. Finally, the tests do not cover Laravel Zero or Lumen (or Nova, for that matter).

The drawback with this architecture is that changes meant to be backwards compatible could only be verified by manually changing composer JSON and, in the case of PHP engine compatibility, by running with engine alternatives. Additionally, if the package had side effects during its logging operation (such as raising a warning), these would not be noticed by the unit tests.

Combined, these drawbacks make forward progress difficult, because they leave dark many potential in-the-field corners we want to see.

This PR adds a Laravel test matrix that covers Laravel 5.5 through Laravel 8 and on supported underlying PHP versions, coordinated to work with the legacy lineages.

[1]:https://packages.tools/testbench/ 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
