### PR TITLE
feat: Lumen test matrix

### DIFF
--- a/.github/workflows/ci-lumen.yml
+++ b/.github/workflows/ci-lumen.yml
@@ -116,7 +116,7 @@ jobs:
           mv tmp-composer.json composer.json
           composer dump-autoload
 
-      - name: Define logging callback that invokes when Laravel logs through Rollbar
+      - name: Define logging callback that invokes when Lumen logs through Rollbar
         working-directory: rollbar-test-app
         run: |
           > app/helpers.php echo '<?php
@@ -139,21 +139,21 @@ jobs:
               public function test_log_call_invokes_rollbar_check_ignore()
               {
                 // generate a random valued log message to check it is passed through the
-                // Laravel logging mechanism into Rollbar
+                // Lumen logging mechanism into Rollbar
                 $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
 
                 \Log::error($value);
 
                 // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),
-                  "Rollbar check_ignore handler not invoked, suggesting an issue integrating Rollbar into Laravel.");
+                  "Rollbar check_ignore handler not invoked, suggesting an issue integrating Rollbar into Lumen.");
                 $this->assertSame($value, file_get_contents(temp_file()),
                   "check_ignore file did not contain expected value, suggesting file left by another process.");
               }
             }
           '
 
-      - name: Invoke the Laravel test suite
+      - name: Invoke the Lumen test suite
         working-directory: rollbar-test-app
         run: |
           ./vendor/bin/phpunit

--- a/.github/workflows/ci-lumen.yml
+++ b/.github/workflows/ci-lumen.yml
@@ -27,12 +27,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4]
-        lumen: [^8]
-        rollbar-php-laravel: [^7]
-        #base#php: [7.4, 7.3, 7.2, 7.1]
-        #base#laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
-        #base#rollbar-php-laravel: [^7, 4.*]
+        #php: [7.4]
+        #lumen: [^8]
+        #rollbar-php-laravel: [^7]
+        php: [7.4, 7.3, 7.2, 7.1]
+        lumen: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        rollbar-php-laravel: [^7, 4.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]
@@ -63,7 +63,6 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
-          composer require rollbar/rollbar-laravel ${{ matrix.rollbar-php-laravel }}
           #local#composer config repositories.local '{"type":"path", "url":".."}'
           #local#composer -vvvv require rollbar/rollbar-laravel
 

--- a/.github/workflows/ci-lumen.yml
+++ b/.github/workflows/ci-lumen.yml
@@ -27,16 +27,64 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        #php: [7.4]
-        #lumen: [^8]
-        #rollbar-php-laravel: [^7]
         php: [7.4, 7.3, 7.2, 7.1]
         lumen: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
         rollbar-php-laravel: [^7, 4.*]
-        #fails#php: [7.0]
-        #fails#laravel: [^5.5]
-        #fails#rollbar-php-laravel: [2.*]
-        #todo#exclude:
+        exclude:
+          # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
+          - laravel: ^8
+            php: 7.2
+          - laravel: ^8
+            php: 7.1
+          - laravel: ^8
+            php: 7.0
+          # Laravel 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
+          - laravel: ^7
+            php: 7.1
+          - laravel: ^7
+            php: 7.0
+          - laravel: ^6
+            php: 7.1
+          - laravel: ^6
+            php: 7.0
+          # Laravel 5.8, 5.7, and 5.6 requires php 7.1.3+, so exclude all PHP versions prior to 7.1.3 for them
+          - laravel: ^5.8
+            php: 7.0
+          - laravel: ^5.7
+            php: 7.0
+          - laravel: ^5.6
+            php: 7.0
+          # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
+          - laravel: ^6
+            rollbar-php-laravel: 4.*
+          - laravel: ^6
+            rollbar-php-laravel: 2.*
+          - laravel: ^7
+            rollbar-php-laravel: 4.*
+          - laravel: ^7
+            rollbar-php-laravel: 2.*
+          - laravel: ^8
+            rollbar-php-laravel: 4.*
+          - laravel: ^8
+            rollbar-php-laravel: 2.*
+          # Laravel 5.6 to 5.8 use rollbar-php-laravel 4.x, so exclude all above that and below that
+          - laravel: ^5.6
+            rollbar-php-laravel: ^7
+          - laravel: ^5.6
+            rollbar-php-laravel: 2.*
+          - laravel: ^5.7
+            rollbar-php-laravel: ^7
+          - laravel: ^5.7
+            rollbar-php-laravel: 2.*
+          - laravel: ^5.8
+            rollbar-php-laravel: ^7
+          - laravel: ^5.8
+            rollbar-php-laravel: 2.*
+          # Laravel 5.5 and below use rollbar-php-laravel 2.x, so exclude all above that
+          - laravel: ^5.5
+            rollbar-php-laravel: ^7
+          - laravel: ^5.5
+            rollbar-php-laravel: 4.*
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Lumen ${{ matrix.lumen }}/Rollbar ${{ matrix.rollbar-php-laravel }}/PHP ${{ matrix.php }}(${{ matrix.os }})

--- a/.github/workflows/ci-lumen.yml
+++ b/.github/workflows/ci-lumen.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
+          composer require rollbar/rollbar-laravel ${{ matrix.rollbar-php-laravel }}
           #local#composer config repositories.local '{"type":"path", "url":".."}'
           #local#composer -vvvv require rollbar/rollbar-laravel
 

--- a/.github/workflows/ci-lumen.yml
+++ b/.github/workflows/ci-lumen.yml
@@ -31,59 +31,59 @@ jobs:
         lumen: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
         rollbar-php-laravel: [^7, 4.*]
         exclude:
-          # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
-          - laravel: ^8
+          # Lumen 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
+          - lumen: ^8
             php: 7.2
-          - laravel: ^8
+          - lumen: ^8
             php: 7.1
-          - laravel: ^8
+          - lumen: ^8
             php: 7.0
-          # Laravel 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
-          - laravel: ^7
+          # Lumen 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
+          - lumen: ^7
             php: 7.1
-          - laravel: ^7
+          - lumen: ^7
             php: 7.0
-          - laravel: ^6
+          - lumen: ^6
             php: 7.1
-          - laravel: ^6
+          - lumen: ^6
             php: 7.0
-          # Laravel 5.8, 5.7, and 5.6 requires php 7.1.3+, so exclude all PHP versions prior to 7.1.3 for them
-          - laravel: ^5.8
+          # Lumen 5.8, 5.7, and 5.6 requires php 7.1.3+, so exclude all PHP versions prior to 7.1.3 for them
+          - lumen: ^5.8
             php: 7.0
-          - laravel: ^5.7
+          - lumen: ^5.7
             php: 7.0
-          - laravel: ^5.6
+          - lumen: ^5.6
             php: 7.0
-          # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
-          - laravel: ^6
+          # Lumen 6+ use rollbar-php-laravel latest, so exclude all below 7
+          - lumen: ^6
             rollbar-php-laravel: 4.*
-          - laravel: ^6
+          - lumen: ^6
             rollbar-php-laravel: 2.*
-          - laravel: ^7
+          - lumen: ^7
             rollbar-php-laravel: 4.*
-          - laravel: ^7
+          - lumen: ^7
             rollbar-php-laravel: 2.*
-          - laravel: ^8
+          - lumen: ^8
             rollbar-php-laravel: 4.*
-          - laravel: ^8
+          - lumen: ^8
             rollbar-php-laravel: 2.*
-          # Laravel 5.6 to 5.8 use rollbar-php-laravel 4.x, so exclude all above that and below that
-          - laravel: ^5.6
+          # Lumen 5.6 to 5.8 use rollbar-php-laravel 4.x, so exclude all above that and below that
+          - lumen: ^5.6
             rollbar-php-laravel: ^7
-          - laravel: ^5.6
+          - lumen: ^5.6
             rollbar-php-laravel: 2.*
-          - laravel: ^5.7
+          - lumen: ^5.7
             rollbar-php-laravel: ^7
-          - laravel: ^5.7
+          - lumen: ^5.7
             rollbar-php-laravel: 2.*
-          - laravel: ^5.8
+          - lumen: ^5.8
             rollbar-php-laravel: ^7
-          - laravel: ^5.8
+          - lumen: ^5.8
             rollbar-php-laravel: 2.*
-          # Laravel 5.5 and below use rollbar-php-laravel 2.x, so exclude all above that
-          - laravel: ^5.5
+          # Lumen 5.5 and below use rollbar-php-laravel 2.x, so exclude all above that
+          - lumen: ^5.5
             rollbar-php-laravel: ^7
-          - laravel: ^5.5
+          - lumen: ^5.5
             rollbar-php-laravel: 4.*
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"

--- a/.github/workflows/ci-lumen.yml
+++ b/.github/workflows/ci-lumen.yml
@@ -1,0 +1,159 @@
+# Primary CI checks for Rollbar-PHP-Laravel.
+# We're checking that logging within Laravel passes through the Rollbar Laravel
+# integration when that integration is properly installed. We make this check
+# for all supported combinations of Laravel, Rollbar, and PHP. We are not
+# checking that messages are properly sent to Rollbar: that's handled by
+# rollbar-php.
+#
+# Test with act:
+#   brew install act
+#   act -P ubuntu-latest=shivammathur/node:latest
+#
+# @see https://github.com/nektos/act/issues/329
+name: Rollbar-PHP-Laravel CI for Lumen
+
+# Fire this action on pushes to main branch (master) as well as other branches
+# or pull requests. Also, run every day at 02:42 GMT -- this catches failures
+# from dependencies that update independently.
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '42 2 * * *'
+
+jobs:
+  # Check that this runs on all combinations of Laravel we claim to support.
+  laravel-tests:
+    strategy:
+      matrix:
+        os: [ubuntu]
+        php: [7.4]
+        lumen: [^8]
+        rollbar-php-laravel: [^7]
+        #base#php: [7.4, 7.3, 7.2, 7.1]
+        #base#laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        #base#rollbar-php-laravel: [^7, 4.*]
+        #fails#php: [7.0]
+        #fails#laravel: [^5.5]
+        #fails#rollbar-php-laravel: [2.*]
+        #todo#exclude:
+    env:
+      ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
+    name: Lumen ${{ matrix.lumen }}/Rollbar ${{ matrix.rollbar-php-laravel }}/PHP ${{ matrix.php }}(${{ matrix.os }})
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      # Note: this step is currently unused, because we are installing Rollbar
+      # Note: from Packagist 3 steps later. This was done to prove out currently
+      # Note: working combinations from published versions. The next iteration
+      # Note: will move the CI to use the correct branch, so that pre-published
+      # Note: code will be tested. See the #local# comment a few steps down for
+      # Note: proper incorporation.
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      - name: Install PHP and composer environment
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl
+
+      - name: Create Lumen test app
+        run: composer create-project laravel/lumen rollbar-test-app ${{ matrix.lumen }}
+
+      - name: Install rollbar-php-laravel package
+        working-directory: rollbar-test-app
+        run: |
+          composer require rollbar/rollbar-laravel ${{ matrix.rollbar-php-laravel }}
+          #local#composer config repositories.local '{"type":"path", "url":".."}'
+          #local#composer -vvvv require rollbar/rollbar-laravel
+
+          echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
+          echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
+          chmod 400 .env
+
+      - name: Configure Lumen to use Rollbar and configure Rollbar to invoke logging callback
+        working-directory: rollbar-test-app
+        run: |
+          > bootstrap/app.php echo '<?php
+            require_once __DIR__."/../vendor/autoload.php";
+
+            (new Laravel\Lumen\Bootstrap\LoadEnvironmentVariables(dirname(__DIR__)))->bootstrap();
+
+            date_default_timezone_set(env("APP_TIMEZONE", "UTC"));
+
+            $app = new Laravel\Lumen\Application(dirname(__DIR__));
+            $app->withFacades();
+            $app->singleton(Illuminate\Contracts\Debug\ExceptionHandler::class, App\Exceptions\Handler::class);
+            $app->singleton(Illuminate\Contracts\Console\Kernel::class, App\Console\Kernel::class);
+            $app->configure("app");
+
+            $app->register(\Rollbar\Laravel\RollbarServiceProvider::class);
+            $app->configure("logging");
+
+            $app->router->group(["namespace" => "App\Http\Controllers"], function ($router) {
+                require __DIR__."/../routes/web.php";
+            });
+
+            return $app;
+          '
+          mkdir config
+          > config/logging.php echo '<?php return array (
+              "default" => "rollbar",
+              "channels" => array (
+                "rollbar" => array (
+                  "driver" => "monolog",
+                  "handler" => \Rollbar\Laravel\MonologHandler::class,
+                  "access_token" => env("ROLLBAR_TOKEN"),
+                  "level" => "debug",
+                  // use the check_ignore filter to capture log messages for verification
+                  "check_ignore" => "check_ignore",
+                )
+              )
+            );
+          '
+          touch app/helpers.php
+          > tmp-composer.json jq '.autoload += { "files": [ "app/helpers.php" ] }' composer.json
+          mv tmp-composer.json composer.json
+          composer dump-autoload
+
+      - name: Define logging callback that invokes when Laravel logs through Rollbar
+        working-directory: rollbar-test-app
+        run: |
+          > app/helpers.php echo '<?php
+            function temp_file() {
+              return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
+            }
+            function check_ignore($isUncaught, $toLog, $payload) {
+              // write log message to a file for inspection
+              $ok = file_put_contents(temp_file(), (string)$toLog);
+              // return indication that the log should be dropped
+              return true;
+            }
+          '
+
+      - name: Define Lumen tests to exercise and verify logging
+        working-directory: rollbar-test-app
+        run: |
+          > tests/LoggingTest.php echo '<?php
+            class LoggingTest extends \TestCase {
+              public function test_log_call_invokes_rollbar_check_ignore()
+              {
+                // generate a random valued log message to check it is passed through the
+                // Laravel logging mechanism into Rollbar
+                $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
+
+                \Log::error($value);
+
+                // check that we have our random value written into our local file
+                $this->assertFileExists(temp_file(),
+                  "Rollbar check_ignore handler not invoked, suggesting an issue integrating Rollbar into Laravel.");
+                $this->assertSame($value, file_get_contents(temp_file()),
+                  "check_ignore file did not contain expected value, suggesting file left by another process.");
+              }
+            }
+          '
+
+      - name: Invoke the Laravel test suite
+        working-directory: rollbar-test-app
+        run: |
+          ./vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
+          composer require rollbar/rollbar-laravel
           echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
           echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
           chmod 400 .env
@@ -65,6 +66,7 @@ jobs:
                   "handler" => \Rollbar\Laravel\MonologHandler::class,
                   "access_token" => env("ROLLBAR_TOKEN"),
                   "level" => "debug",
+                  // use the check_ignore filter to capture log messages for verification
                   "check_ignore" => "check_ignore",
                 )
               )
@@ -83,8 +85,10 @@ jobs:
               return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
             }
             function check_ignore($isUncaught, $toLog, $payload) {
+              // write log message to a file for inspection
               file_put_contents(temp_file(), (string)$toLog);
-              return false;
+              // return indication that the log should be dropped
+              return true;
             }
           '
 
@@ -96,8 +100,13 @@ jobs:
             class LoggingTest extends \Tests\TestCase {
               public function test_log_call_invokes_rollbar_check_ignore()
               {
-                $value = env("GITHUB_RUN_ID");
+                // generate a random valued log message to check it is passed through the
+                // Laravel logging mechanism into Rollbar
+                $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
+
                 \Log::error($value);
+
+                // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),
                   "Rollbar check_ignore handler not invoked, suggesting an issue integrating Rollbar into Laravel.");
                 $this->assertSame($value, file_get_contents(temp_file()),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1, 7.0]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
-        rollbar-php-laravel: [^7, 4.*, 2.*]
+        php: [7.4, 7.3, 7.2, 7.1]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        rollbar-php-laravel: [^7, 4.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]
@@ -140,14 +140,11 @@ jobs:
         run: |
           > app/helpers.php echo '<?php
             function temp_file() {
-              $x = env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
-              var_dump($x);
-              return $x;
+              return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
             }
             function check_ignore($isUncaught, $toLog, $payload) {
               // write log message to a file for inspection
               $ok = file_put_contents(temp_file(), (string)$toLog);
-              var_dump($ok);
               // return indication that the log should be dropped
               return true;
             }
@@ -165,9 +162,7 @@ jobs:
                 // Laravel logging mechanism into Rollbar
                 $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
 
-                var_dump("x");
                 \Log::error($value);
-                var_dump("y");
 
                 // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
-        rollbar-php-laravel: [^7, 4.*]
+        php: [7.4]
+        laravel: [^8]
+        rollbar-php-laravel: [^7]
+        #simplify#php: [7.4, 7.3, 7.2, 7.1]
+        #simplify#laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        #simplify#rollbar-php-laravel: [^7, 4.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: Rollbar-PHP-Laravel CI
 
 # Fire this action on pushes to main branch (master) as well as other branches
 # or pull requests. Also, run every day at 02:42 GMT -- this catches failures
-# from dependencies that update indepdently.
+# from dependencies that update independently.
 on:
   push:
   pull_request:
@@ -17,21 +17,17 @@ on:
     - cron: '42 2 * * *'
 
 jobs:
-  # Check that this runs on PHP on all versions we claim to support, on both
-  # UNIX-like and Windows environments, and that use both the lowest possible
-  # compatible version as well as the most-recent stable version. This will
-  # fail-fast by default, so we include our edgiest versions (currently 7.4)
-  # first as they're most likely to fail.
-  # @seealso https://freek.dev/1546
-  # @seealso https://www.dereuromark.de/2019/01/04/test-composer-dependencies-with-prefer-lowest/
-  php-tests:
+  # Check that this runs on all combinations of Laravel we claim to support.
+  laravel-tests:
     strategy:
       matrix:
-        php: [7.3, 7.2]
-        dependency: [stable]
         os: [ubuntu]
-
-    name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
+        php: [7.4]
+        laravel: [^7.0]
+        rollbar-php-laravel: [^7.0]
+    env:
+      ROLLBAR_TOKEN: ad865e76e7fb496fab096ac07b1dbabb
+    name: Laravel ${{ matrix.laravel }} PHP ${{ matrix.php }} ${{ matrix.os }} Rollbar ${{ matrix.rollbar-php }}
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout the code
@@ -42,29 +38,70 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl
-          ini-values: ${{ matrix.ini }}
-          coverage: xdebug
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Create Laravel test app
+        run: composer create-project laravel/laravel rollbar-test-app
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}-${{ matrix.dependency }}-
-          restore-keys: ${{ matrix.os }}-composer-${{ matrix.dependency }}-
+      - name: Install rollbar-php-laravel package
+        working-directory: rollbar-test-app
+        run: |
+          echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
+          echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
+          chmod 400 .env
 
-      - name: Install dependencies
-        run: composer update --prefer-${{ matrix.dependency }} --prefer-dist --no-interaction
+      - name: Configure Laravel to use Rollbar and configure Rollbar to invoke logging callback
+        working-directory: rollbar-test-app
+        run: |
+          > config/logging.php echo '<?php return array (
+              "default" => "rollbar",
+              "channels" => array (
+                "rollbar" => array (
+                  "driver" => "monolog",
+                  "handler" => \Rollbar\Laravel\MonologHandler::class,
+                  "access_token" => env("ROLLBAR_TOKEN"),
+                  "level" => "debug",
+                  "check_ignore" => "check_ignore",
+                )
+              )
+            );
+          '
+          touch app/helpers.php
+          > tmp-composer.json jq '.autoload += { "files": [ "app/helpers.php" ] }' composer.json
+          mv tmp-composer.json composer.json
+          composer dump-autoload
 
-      - name: Make logs directory
-        run: mkdir -p build/logs
+      - name: Define logging callback that invokes when Laravel logs through Rollbar
+        working-directory: rollbar-test-app
+        run: |
+          > app/helpers.php echo '<?php
+            function temp_file() {
+              return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
+            }
+            function check_ignore($isUncaught, $toLog, $payload) {
+              file_put_contents(temp_file(), (string)$toLog);
+              return false;
+            }
+          '
 
-      - name: Execute tests
-        run: composer test
+      - name: Define Laravel tests to exercise and verify logging
+        working-directory: rollbar-test-app
+        run: |
+          > tests/Feature/LoggingTest.php echo '<?php
+            namespace Tests\Feature;
+            class LoggingTest extends \Tests\TestCase {
+              public function test_log_call_invokes_rollbar_check_ignore()
+              {
+                $value = env("GITHUB_RUN_ID");
+                \Log::error($value);
+                $this->assertFileExists(temp_file(),
+                  "Rollbar check_ignore handler not invoked, suggesting an issue integrating Rollbar into Laravel.");
+                $this->assertSame($value, file_get_contents(temp_file()),
+                  "check_ignore file did not contain expected value, suggesting file left by another process.");
+              }
+            }
+          '
 
-      - name: Report results
-        if: success()
-        run: ./vendor/bin/php-coveralls -v || true
+      - name: Invoke the Laravel test suite
+        working-directory: rollbar-test-app
+        run: |
+          ./vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         laravel: [^7.0]
         rollbar-php-laravel: [^7.0]
     env:
-      ROLLBAR_TOKEN: ad865e76e7fb496fab096ac07b1dbabb
+      ROLLBAR_TOKEN: 00000000000000000000000000000000
     name: Laravel ${{ matrix.laravel }} PHP ${{ matrix.php }} ${{ matrix.os }} Rollbar ${{ matrix.rollbar-php }}
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu]
         php: [7.4, 7.3, 7.2, 7.1, 7.0]
         laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
-        rollbar-php-laravel: [^7, ^4, ^2]
+        rollbar-php-laravel: [^7, 4.*, 2.*]
         exclude:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8
@@ -49,35 +49,35 @@ jobs:
             php: 7.0
           # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
           - laravel: ^6
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
           - laravel: ^6
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^7
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
           - laravel: ^7
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^8
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
           - laravel: ^8
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           # Laravel 5.6 to 5.8 use rollbar-php-laravel 4.x, so exclude all above that and below that
           - laravel: ^5.6
             rollbar-php-laravel: ^7
           - laravel: ^5.6
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^5.7
             rollbar-php-laravel: ^7
           - laravel: ^5.7
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           - laravel: ^5.8
             rollbar-php-laravel: ^7
           - laravel: ^5.8
-            rollbar-php-laravel: ^2
+            rollbar-php-laravel: 2.*
           # Laravel 5.5 and below use rollbar-php-laravel 2.x, so exclude all above that
           - laravel: ^5.5
             rollbar-php-laravel: ^7
           - laravel: ^5.5
-            rollbar-php-laravel: ^4
+            rollbar-php-laravel: 4.*
     env:
       ROLLBAR_TOKEN: 00000000000000000000000000000000
     name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
@@ -98,7 +98,7 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
-          composer require rollbar/rollbar-laravel:${{ matrix.rollbar-php-laravel }}
+          composer require rollbar/rollbar-laravel ${{ matrix.rollbar-php-laravel }}
           echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
           echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
           chmod 400 .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             rollbar-php-laravel: 4.*
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
-    name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
+    name: Laravel ${{ matrix.laravel }}/Rollbar ${{ matrix.rollbar-php-laravel }}/PHP ${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout the code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4]
-        laravel: [^8]
-        rollbar-php-laravel: [^7]
+        php: [7.4, 7.3, 7.2, 7.1]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        rollbar-php-laravel: [^7, 4.*]
+        #fails#php: [7.0]
+        #fails#laravel: [^5.5]
+        #fails#rollbar-php-laravel: [2.*]
         exclude:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,60 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4]
-        laravel: [^7.0]
-        rollbar-php-laravel: [^7.0]
+        php: [7.4, 7.3, 7.2, 7.1, 7.0]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
+        rollbar-php-laravel: [^7, ^4, ^2]
+        exclude:
+          # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
+          - laravel: ^8
+            php: 7.2
+          - laravel: ^8
+            php: 7.1
+          - laravel: ^8
+            php: 7.0
+          # Laravel 7 and 6 requires php 7.2+, so exclude all PHP versions prior to 7.2
+          - laravel: ^7
+            php: 7.1
+          - laravel: ^7
+            php: 7.0
+          - laravel: ^6
+            php: 7.1
+          - laravel: ^6
+            php: 7.0
+          # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
+          - laravel: ^6
+            rollbar-php-laravel: ^4
+          - laravel: ^6
+            rollbar-php-laravel: ^2
+          - laravel: ^7
+            rollbar-php-laravel: ^4
+          - laravel: ^7
+            rollbar-php-laravel: ^2
+          - laravel: ^8
+            rollbar-php-laravel: ^4
+          - laravel: ^8
+            rollbar-php-laravel: ^2
+          # Laravel 5.6 to 5.8 use rollbar-php-laravel 4.x, so exclude all above that and below that
+          - laravel: ^5.6
+            rollbar-php-laravel: ^7
+          - laravel: ^5.6
+            rollbar-php-laravel: ^2
+          - laravel: ^5.7
+            rollbar-php-laravel: ^7
+          - laravel: ^5.7
+            rollbar-php-laravel: ^2
+          - laravel: ^5.8
+            rollbar-php-laravel: ^7
+          - laravel: ^5.8
+            rollbar-php-laravel: ^2
+          # Laravel 5.5 and below use rollbar-php-laravel 2.x, so exclude all above that
+          - laravel: ^5.5
+            rollbar-php-laravel: ^7
+          - laravel: ^5.5
+            rollbar-php-laravel: ^4
     env:
       ROLLBAR_TOKEN: 00000000000000000000000000000000
-    name: Laravel ${{ matrix.laravel }} PHP ${{ matrix.php }} ${{ matrix.os }} Rollbar ${{ matrix.rollbar-php }}
+    name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout the code
@@ -50,7 +98,7 @@ jobs:
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app
         run: |
-          composer require rollbar/rollbar-laravel
+          composer require rollbar/rollbar-laravel:${{ matrix.rollbar-php-laravel }}
           echo "ROLLBAR_TOKEN=${ROLLBAR_TOKEN}" >> .env
           echo "GITHUB_RUN_ID=${GITHUB_RUN_ID}" >> .env
           chmod 400 .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           - laravel: ^5.5
             rollbar-php-laravel: 4.*
     env:
-      ROLLBAR_TOKEN: 00000000000000000000000000000000
+      ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: ${{ matrix.laravel }}/${{ matrix.rollbar-php-laravel }}/${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
-        rollbar-php-laravel: [^7, 4.*]
+        php: [7.4, 7.3, 7.2, 7.1, 7.0]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
+        rollbar-php-laravel: [^7, 4.*, 2.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           extensions: curl
 
       - name: Create Laravel test app
-        run: composer create-project laravel/laravel rollbar-test-app
+        run: composer create-project laravel/laravel rollbar-test-app ${{ matrix.laravel }}
 
       - name: Install rollbar-php-laravel package
         working-directory: rollbar-test-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
 # Primary CI checks for Rollbar-PHP-Laravel.
+# We're checking that logging within Laravel passes through the Rollbar Laravel
+# integration when that integration is properly installed. We make this check
+# for all supported combinations of Laravel, Rollbar, and PHP. We are not
+# checking that messages are properly sent to Rollbar: that's handled by
+# rollbar-php.
 #
 # Test with act:
 #   brew install act

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
         run: |
           > app/helpers.php echo '<?php
             function temp_file() {
-              return env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
+              $x = env("RUNNER_TEMP") . DIRECTORY_SEPARATOR . env("GITHUB_RUN_ID") . ".tmp.txt";
+              var_dump($x);
+              return $x;
             }
             function check_ignore($isUncaught, $toLog, $payload) {
               // write log message to a file for inspection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,8 @@ jobs:
             }
             function check_ignore($isUncaught, $toLog, $payload) {
               // write log message to a file for inspection
-              file_put_contents(temp_file(), (string)$toLog);
+              $ok = file_put_contents(temp_file(), (string)$toLog);
+              var_dump($ok);
               // return indication that the log should be dropped
               return true;
             }
@@ -167,7 +168,9 @@ jobs:
                 // Laravel logging mechanism into Rollbar
                 $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
 
+                var_dump("x");
                 \Log::error($value);
+                var_dump("y");
 
                 // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4]
-        laravel: [^8]
-        rollbar-php-laravel: [^7]
-        #simplify#php: [7.4, 7.3, 7.2, 7.1]
-        #simplify#laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
-        #simplify#rollbar-php-laravel: [^7, 4.*]
+        php: [7.4, 7.3, 7.2, 7.1]
+        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6]
+        rollbar-php-laravel: [^7, 4.*]
         #fails#php: [7.0]
         #fails#laravel: [^5.5]
         #fails#rollbar-php-laravel: [2.*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
     name: Laravel ${{ matrix.laravel }}/Rollbar ${{ matrix.rollbar-php-laravel }}/PHP ${{ matrix.php }}(${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
+      # Note: this step is currently unused, because we are installing Rollbar
+      # Note: from Packagist 3 steps later. This was done to prove out currently
+      # Note: working combinations from published versions. The next iteration
+      # Note: will move the CI to use the correct branch, so that pre-published
+      # Note: code will be tested.
       - name: Checkout the code
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [7.4, 7.3, 7.2, 7.1, 7.0]
-        laravel: [^8, ^7, ^6, ^5.8, ^5.7, ^5.6, ^5.5]
-        rollbar-php-laravel: [^7, 4.*, 2.*]
+        php: [7.4]
+        laravel: [^8]
+        rollbar-php-laravel: [^7]
         exclude:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8
@@ -46,6 +46,13 @@ jobs:
           - laravel: ^6
             php: 7.1
           - laravel: ^6
+            php: 7.0
+          # Laravel 5.8, 5.7, and 5.6 requires php 7.1.3+, so exclude all PHP versions prior to 7.1.3 for them
+          - laravel: ^5.8
+            php: 7.0
+          - laravel: ^5.7
+            php: 7.0
+          - laravel: ^5.6
             php: 7.0
           # Laravel 6+ use rollbar-php-laravel latest, so exclude all below 7
           - laravel: ^6


### PR DESCRIPTION
## Description of the change

Adds a test matrix for Lumen, similar to how is done for Laravel in #115. The failures here are all expected, owing to the incorrect handling of `session`. As a reminder, this pass is meant to document the current state of the integration: later passes will check master against the relevant versions.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
