### PR TITLE
Laravel 9.x support (8.0 release?)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "rollbar/rollbar": "^2"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
         "mockery/mockery": "^1",
         "php-coveralls/php-coveralls": "^2.2",
         "squizlabs/php_codesniffer": "3.*",


### PR DESCRIPTION
## Description of the change

Support illuminate/support 9.x, therefore being Laravel 9.x compatible (whilst still compatible with older Laravel versions too). Last update to 7.0 of this package only needed a similar change to composer.json, so just getting the ball rolling. I can't spot anything obviously different in illuminate/support 9.x which would break anything this package is using.. https://github.com/illuminate/support/compare/8.x...9.x

## Type of change

- [x] Maintenance
- [x] New release

## Related issues

See comment here https://github.com/rollbar/rollbar-php-laravel/issues/120