### PR TITLE
Laravel Version 9 Compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "php": "^8.0",
         "rollbar/rollbar": "^2"
     },
     "require-dev": {


### PR DESCRIPTION
## Description of the change

- Bumps php version requirement to 8.0 ([Laravel minimum version requirement is now 8.0.2](https://github.com/laravel/laravel/blob/9.x/composer.json))
- removes `illuminate/support` requirement

Fixes requirement conflict with `laravel/framework` version 9. Problem occurs when running `composer update` in a new Laravel project with this package, or when upgrading an existing project that uses this package. The following error is produced:
```
    - Only one of these can be installed: illuminate/support[v5.5.0, ..., 5.8.x-dev, v6.0.0, ..., 6.x-dev, v7.0.0, ..., 7.x-dev, v8.0.0, ..., 8.x-dev, v9.0.0-beta.1, ..., 9.x-dev], laravel/framework[v9.0.0-beta.1, ..., 9.x-dev]. laravel/framework replaces illuminate/support and thus cannot coexist with it.
    - Root composer.json requires laravel/framework ^9.0 -> satisfiable by laravel/framework[v9.0.0-beta.1, ..., 9.x-dev].
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
