### PR TITLE
Fixed typo in php version array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [8.1, 8.0 7.4, 7.3, 7.2]
+        php: [8.1, 8.0, 7.4, 7.3, 7.2]
         laravel: [^9, ^8, ^7, ^6]
         exclude:
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3


### PR DESCRIPTION
## Description of the change

This fixes a typo in the main CI GitHub Action. Each PHP version in the array should be separated by a comma.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
