### PR TITLE
Bump to rollbar-php v3.1.0 for PHP 8.0 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.2|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "rollbar/rollbar": "^2"
+        "rollbar/rollbar": "^3.1"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.2|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "rollbar/rollbar": "^3.1"
+        "rollbar/rollbar": "^2.0 | ^3.1"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",


### PR DESCRIPTION
## Description of the change

Users on PHP 8.0+ started getting deprecation notices:

> PHP Deprecated:  Rollbar\Payload\Level implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /app/vendor/rollbar/rollbar/src/Payload/Level.php on line 5

This was fixed in rollbar-php v3.1.0, so I bumped it and ran the test suite. It's showing green lights so... whoppeee let's go! 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fixes https://github.com/rollbar/rollbar-php-laravel/issues/120
- Related to https://github.com/rollbar/rollbar-php/issues/555

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
