### PR TITLE
Fixing PHP versions of Actions CI in Laravel 6 and 7.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
         php: [8.1, 8.0, 7.4, 7.3, 7.2]
         laravel: [^9, ^8, ^7, ^6]
         exclude:
+          # Laravel 6 requires php 7.2-8.0, so exclude all php versions after 8.1
+          - laravel: ^6
+            php: 8.1
+          # Laravel 7 requires php 7.2-8.0, so exclude all php versions after 8.1
+          - laravel: ^7
+            php: 8.1
           # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
           - laravel: ^8
             php: 7.2


### PR DESCRIPTION
## Description of the change
Laravel 6 and 7 requires PHP 7.2 - 8.0, so exclude all PHP versions after 8.1 on GitHub Actions CI.
https://laravel.com/docs/master/releases#support-policy

Seeing #129 CIs failing, I created it as another PR.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
