### PR TITLE
Fixed v2 and v4 scheduled CI checks out master branch

### DIFF
--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -42,8 +42,15 @@ jobs:
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - name: Checkout the code
+      - name: Checkout the PR Branch
         uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Checkout the v2 Branch
+        uses: actions/checkout@v2
+        # Set the branch to our version branch not master when scheduled.
+        ref: 'next/2.x/main'
+        if: ${{ github.event_name == 'schedule' }}
 
       - name: Install PHP and composer environment
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -42,8 +42,15 @@ jobs:
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - name: Checkout the code
+      - name: Checkout the PR Branch
         uses: actions/checkout@v2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Checkout the v4 Branch
+        uses: actions/checkout@v2
+        # Set the branch to our version branch not master when scheduled.
+        ref: 'next/4.x/main'
+        if: ${{ github.event_name == 'schedule' }}
 
       - name: Install PHP and composer environment
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Description of the change

This PR fixes the failing CI on v2 and v4 branches. The reason the scheduled CI has been failing is that the `master` branch is being checked out. This fixes it so that we are checking out the respective v2 and v4 branches instead.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
