### PR TITLE
BC - Updates for Laravel 10 and the MonologHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10.0",
-        "rollbar/rollbar": "^3.1"
+        "rollbar/rollbar": "^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
+        "orchestra/testbench": "^8.0",
         "mockery/mockery": "^1",
         "php-coveralls/php-coveralls": "^2.2",
         "squizlabs/php_codesniffer": "3.*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10.0",
-        "rollbar/rollbar": "^2.0 | ^3.1"
+        "rollbar/rollbar": "^3.1"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "php": "^8.1",
+        "illuminate/support": "^10.0",
         "rollbar/rollbar": "^2.0 | ^3.1"
     },
     "require-dev": {

--- a/src/MonologHandler.php
+++ b/src/MonologHandler.php
@@ -3,28 +3,41 @@
 namespace Rollbar\Laravel;
 
 use Monolog\Handler\RollbarHandler;
+use Monolog\LogRecord;
 
 class MonologHandler extends RollbarHandler
 {
     protected $app;
 
+    /**
+     * @param $app
+     * @return void
+     */
     public function setApp($app)
     {
         $this->app = $app;
     }
 
-    protected function write(array $record): void
+    /**
+     * @param LogRecord $record
+     * @return void
+     */
+    protected function write(LogRecord $record): void
     {
-        $record['context'] = $this->addContext($record['context']);
-        parent::write($record);
+        parent::write(new LogRecord($record->datetime,
+            $record->channel,
+            $record->level,
+            $record->message,
+            (array_merge($record->toArray(), [ 'context' => $this->addContext($record->context) ])),
+            $record->extra,
+            $record->formatted));
     }
 
     /**
-     * Add Laravel specific information to the context.
-     *
      * @param array $context
+     * @return array
      */
-    protected function addContext(array $context = [])
+    protected function addContext(array $context = []): array
     {
         $config = $this->rollbarLogger->extend([]);
 
@@ -47,7 +60,7 @@ class MonologHandler extends RollbarHandler
                     } elseif (method_exists($data, 'getKey')) {
                         $person['id'] = $data->getKey();
                     }
-                    
+
                     if (isset($person['id'])) {
                         if (isset($data->username)) {
                             $person['username'] = $data->username;

--- a/src/MonologHandler.php
+++ b/src/MonologHandler.php
@@ -28,7 +28,7 @@ class MonologHandler extends RollbarHandler
             $record->channel,
             $record->level,
             $record->message,
-            array_merge($record->toArray()['context'], $this->addContext($record->context)),
+            $this->addContext($record->context),
             $record->extra,
             $record->formatted));
     }

--- a/src/MonologHandler.php
+++ b/src/MonologHandler.php
@@ -28,7 +28,7 @@ class MonologHandler extends RollbarHandler
             $record->channel,
             $record->level,
             $record->message,
-            (array_merge($record->toArray(), [ 'context' => $this->addContext($record->context) ])),
+            array_merge($record->toArray()['context'], $this->addContext($record->context)),
             $record->extra,
             $record->formatted));
     }


### PR DESCRIPTION
Updated the composer.json file to be inline with Laravel 10 - dropped all PHP support except 8.1 and added illuminate/support 10 only

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
