### PR TITLE
Fixed required minimum stability causing the CI tests to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,23 +68,16 @@ jobs:
         run: composer create-project laravel/laravel rollbar-test-app ${{ matrix.laravel }}
 
       - name: Install that code using Composer rigged to look in the parent directory
-        id: composer_require
         working-directory: rollbar-test-app
-        continue-on-error: true
+        # We arbitrarily set the version to 1.0.0, because we just need composer
+        # to consider it to be stable.
         run: |
-          composer config repositories.local '{"type":"path", "url":".."}'
-          composer require rollbar/rollbar-laravel
-          
-      - name: Try to resolve requirements into an installable set of packages
-        working-directory: rollbar-test-app
-        # This adds time, so only run this if the previous step fails.
-        if: ${{ steps.composer_require.outcome == 'failure' }}
-        # We are ok removing the lock file since it was generated in step 3,
-        # before we included all our requirements.
-        run: |
-          rm composer.lock
-          composer require rollbar/rollbar-laravel
-          composer install
+          composer config repositories.local '{
+            "type":"path", 
+            "url":"..", 
+            "options": {"versions": {"rollbar/rollbar-laravel": "1.0.0"}}
+          }'
+          composer require rollbar/rollbar-laravel -W
       
       - name: Setup .env
         working-directory: rollbar-test-app


### PR DESCRIPTION
## Description of the change

Our CI tests are failing because composer is trying to only install **stable** dependencies. Installing `rollbar/rollbar-laravel` from our a path repository without any version in the `composer.json` file [causes composer to assume its version is `dev-master`](https://getcomposer.org/doc/05-repositories.md#path). `dev-master` has a stability of `dev`.

To fix this problem I added an arbitrary stable version `1.0.0` to the `rollbar/rollbar-laravel` package in the test app `composer.json` file.

The other option would be to change the minimum stability requirement in the test app to `dev`. However, this could have some unintended side effects if other unstable packages are installed.

The last change is replacing the `Try to resolve requirements into an installable set of packages` step with the added `-W` flag on the previous step. It essentially does the same thing but better. This also means we can remove the `id` and `continue-on-error` keys.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
