### PR TITLE
Updated the CI test workflow for v8 and Laravel 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,25 +31,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [8.1, 8.0, 7.4, 7.3, 7.2]
-        laravel: [^9, ^8, ^7, ^6]
-        exclude:
-          # Laravel 6 requires php 7.2-8.0, so exclude all php versions after 8.1
-          - laravel: ^6
-            php: 8.1
-          # Laravel 7 requires php 7.2-8.0, so exclude all php versions after 8.1
-          - laravel: ^7
-            php: 8.1
-          # Laravel 8 requires php 7.3+, so exclude all PHP versions prior to 7.3
-          - laravel: ^8
-            php: 7.2
-          # Laravel 9 requires php ^8.0.2, so exclude all PHP versions prior to 8.0.2
-          - laravel: ^9
-            php: 7.2
-          - laravel: ^9
-            php: 7.3
-          - laravel: ^9
-            php: 7.4
+        php: [8.2, 8.1]
+        laravel: [^10]
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})
@@ -77,6 +60,8 @@ jobs:
             "url":"..", 
             "options": {"versions": {"rollbar/rollbar-laravel": "1.0.0"}}
           }'
+          composer config minimum-stability dev
+          composer config prefer-stable true
           composer require rollbar/rollbar-laravel -W
       
       - name: Setup .env
@@ -135,7 +120,7 @@ jobs:
                 // Laravel logging mechanism into Rollbar
                 $value = sprintf("%s-%s", env("GITHUB_RUN_ID"), rand());
 
-                \Log::error($value);
+                \Illuminate\Support\Facades\Log::error($value);
 
                 // check that we have our random value written into our local file
                 $this->assertFileExists(temp_file(),


### PR DESCRIPTION
## Description of the change

This PR makes it so that our tests will run for the `master` branch. This is for the upcoming `v8.x` and above. Tests for the previous version `v7.x` of our Laravel package have been moved to the `ci-7.x.yml` file in #144.

To make the tests run we need to temporarily include the following lines in the install step.

```
composer config minimum-stability dev
composer config prefer-stable true
```

Once we release stable `v4.0.0` of the core `rollbar/rollbar` library, we can remove these two lines.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
