### PR TITLE
Improved missing typing and comments

### DIFF
--- a/src/MonologHandler.php
+++ b/src/MonologHandler.php
@@ -2,39 +2,53 @@
 
 namespace Rollbar\Laravel;
 
+use Illuminate\Contracts\Foundation\Application;
 use Monolog\Handler\RollbarHandler;
 use Monolog\LogRecord;
 
 class MonologHandler extends RollbarHandler
 {
-    protected $app;
+    protected Application $app;
 
     /**
-     * @param $app
+     * Sets the Laravel application, so it can be used to get the current user and session data later.
+     *
+     * @param Application $app The Laravel application.
+     *
      * @return void
      */
-    public function setApp($app)
+    public function setApp(Application $app): void
     {
         $this->app = $app;
     }
 
     /**
-     * @param LogRecord $record
+     * Custom write method to add the Laravel context to the log record for Rollbar.
+     *
+     * @param LogRecord $record The Monolog log record.
+     *
      * @return void
      */
     protected function write(LogRecord $record): void
     {
-        parent::write(new LogRecord($record->datetime,
-            $record->channel,
-            $record->level,
-            $record->message,
-            $this->addContext($record->context),
-            $record->extra,
-            $record->formatted));
+        parent::write(
+            new LogRecord(
+                $record->datetime,
+                $record->channel,
+                $record->level,
+                $record->message,
+                $this->addContext($record->context),
+                $record->extra,
+                $record->formatted
+            )
+        );
     }
 
     /**
-     * @param array $context
+     * Adds the Laravel context to the log record for Rollbar. This includes person and session data.
+     *
+     * @param array $context The {@see LogRecord::context} array.
+     *
      * @return array
      */
     protected function addContext(array $context = []): array

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -4,7 +4,7 @@ use Rollbar\Rollbar;
 use Rollbar\RollbarLogger;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
-use Rollbar\Laravel\MonologHandler;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 
@@ -13,14 +13,14 @@ class RollbarServiceProvider extends ServiceProvider
     /**
      * Register the service provider.
      */
-    public function register()
+    public function register(): void
     {
         // Don't register rollbar if it is not configured.
         if ($this->stop() === true) {
             return;
         }
 
-        $this->app->singleton(RollbarLogger::class, function ($app) {
+        $this->app->singleton(RollbarLogger::class, function (Application $app) {
 
             $defaults = [
                 'environment'       => $app->environment(),
@@ -54,7 +54,7 @@ class RollbarServiceProvider extends ServiceProvider
             return Rollbar::logger();
         });
 
-        $this->app->singleton(MonologHandler::class, function ($app) {
+        $this->app->singleton(MonologHandler::class, function (Application $app) {
 
             $level = static::config('level', 'debug');
             
@@ -66,7 +66,7 @@ class RollbarServiceProvider extends ServiceProvider
     }
 
     /**
-     * Check if we should prevent the service from registering
+     * Check if we should prevent the service from registering.
      *
      * @return boolean
      */
@@ -82,15 +82,16 @@ class RollbarServiceProvider extends ServiceProvider
     }
 
     /**
-     * Return a rollbar logging config
+     * Return a rollbar logging config.
      *
-     * @param array|string $key
-     * @param mixed $default
+     * @param string $key     The config key to lookup.
+     * @param mixed  $default The default value to return if the config is not found.
+     *
      * @return mixed
      */
-    protected static function config($key = '', $default = null)
+    protected static function config(string $key = '', mixed $default = null): mixed
     {
-        $envKey = 'ROLLBAR_'.strtoupper($key);
+        $envKey = 'ROLLBAR_' . strtoupper($key);
 
         if ($envKey === 'ROLLBAR_ACCESS_TOKEN') {
             $envKey = 'ROLLBAR_TOKEN';

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -11,9 +11,10 @@ use Mockery;
 
 class RollbarTest extends \Orchestra\Testbench\TestCase
 {
+    private string $access_token = 'B42nHP04s06ov18Dv8X7VI4nVUs6w04X';
+
     protected function setUp(): void
     {
-        $this->access_token = 'B42nHP04s06ov18Dv8X7VI4nVUs6w04X';
         putenv('ROLLBAR_TOKEN=' . $this->access_token);
 
         parent::setUp();


### PR DESCRIPTION
## Description of the change

This PR does two things...

1. It adds missing type annotations and comments explaining the methods and their inputs and outputs. This is a BC because it must be respected by any user created class extending one of these.
2. It moves the `$access_token` in our test suite from being a dynamically declared property to being defined on the class for [compatibility with PHP 8.2](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties).
 
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
