### PR TITLE
Added the missing 'framework' parameter to the Rollbar config.

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -49,6 +49,7 @@ class RollbarServiceProvider extends ServiceProvider
             if ($handler === AgentHandler::class) {
                 $config['handler'] = 'agent';
             }
+            $config['framework'] = 'laravel ' . app()->version();
             Rollbar::init($config, $handleException, $handleError, $handleFatal);
 
             return Rollbar::logger();


### PR DESCRIPTION
## Description of the change

We have not previously been sending the framework information to the Rollbar service. This updates the Rollbar config to include `laravel` and the version that is being used.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
