### PR TITLE
Fixed the branch that is checked out when scheduled v7 tests run.

### DIFF
--- a/.github/workflows/ci-7.x.yml
+++ b/.github/workflows/ci-7.x.yml
@@ -57,8 +57,16 @@ jobs:
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - name: Checkout the code
+      - name: Checkout the PR Branch
+        uses: actions/checkout@v3
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Checkout the v7 Branch
         uses: actions/checkout@v2
+        if: ${{ github.event_name == 'schedule' }}
+        with:
+          # Set the branch to our version branch not master when scheduled.
+          ref: 'next/7.x/main'
 
       - name: Install PHP and composer environment
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Description of the change

The scheduled tests for the [next/7.x/main](https://github.com/rollbar/rollbar-php-laravel/tree/next/7.x/main) branch are checking out the `master` branch. This fixes that.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
