### PR TITLE
Added support for the illuminate/support package to also accept version 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0",
+        "illuminate/support": "^10.0|^11.0",
         "rollbar/rollbar": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
With this merge request, it will add support for Laravel 11.
The only change that is needed for supporting Laravel 11 is allowing the Illuminate package to accept version 11.0 or higher.

I made this MR because I was already working with Laravel 11 (dev-master) and wanted to install this package as well, but was running into the issue that it's not supporting version 11.
After bumping the version inside a local installation, I ran all error logging command versions, and they were all added to Rollbar issue console.

> Don't know if you wanted to keep that PR template boilerplate, if so please let me know I can add it again :)
