### PR TITLE
Added telemetry support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: curl
 
+      - name: Install dependencies
+        run: composer update --prefer-${{ matrix.dependency }} --prefer-dist --no-interaction
+
+      - name: Execute Rollbar tests
+        run: composer test
+
       - name: Create Laravel test app
         run: composer create-project laravel/laravel rollbar-test-app ${{ matrix.laravel }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           extensions: curl
 
       - name: Install dependencies
-        run: composer update --prefer-${{ matrix.dependency }} --prefer-dist --no-interaction
+        run: composer update --prefer-dist --no-interaction
 
       - name: Execute Rollbar tests
         run: composer test

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
             "Rollbar\\Laravel\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Rollbar\\Laravel\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10.0|^11.0",
-        "rollbar/rollbar": "^4.0"
+        "rollbar/rollbar": "v4.1.0-rc"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="tests/bootstrap.php"
          colors="true"
@@ -8,15 +9,15 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="true"
->
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -1,5 +1,7 @@
 <?php namespace Rollbar\Laravel;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Events\Dispatcher;
 use Rollbar\Rollbar;
 use Rollbar\RollbarLogger;
 use Illuminate\Support\Arr;
@@ -11,6 +13,11 @@ use Illuminate\Support\ServiceProvider;
 class RollbarServiceProvider extends ServiceProvider
 {
     /**
+     * The telemetry event listener.
+     */
+    protected TelemetryListener $telemetryListener;
+
+    /**
      * Register the service provider.
      */
     public function register(): void
@@ -21,35 +28,11 @@ class RollbarServiceProvider extends ServiceProvider
         }
 
         $this->app->singleton(RollbarLogger::class, function (Application $app) {
+            $config = $this->getConfigs($app);
 
-            $defaults = [
-                'environment'       => $app->environment(),
-                'root'              => base_path(),
-                'handle_exception'  => true,
-                'handle_error'      => true,
-                'handle_fatal'      => true,
-            ];
-
-            $config = array_merge($defaults, $app['config']->get('logging.channels.rollbar', []));
-
-            $config['access_token'] = static::config('access_token');
-
-            if (empty($config['access_token'])) {
-                throw new InvalidArgumentException('Rollbar access token not configured');
-            }
-
-            $handleException = (bool) Arr::pull($config, 'handle_exception');
-            $handleError = (bool) Arr::pull($config, 'handle_error');
-            $handleFatal = (bool) Arr::pull($config, 'handle_fatal');
-
-            // Convert a request for the Rollbar agent to handle the logs to
-            // the format expected by `Rollbar::init`.
-            // @see https://github.com/rollbar/rollbar-php-laravel/issues/85
-            $handler = Arr::get($config, 'handler');
-            if ($handler === AgentHandler::class) {
-                $config['handler'] = 'agent';
-            }
-            $config['framework'] = 'laravel ' . app()->version();
+            $handleException = (bool)Arr::pull($config, 'handle_exception');
+            $handleError = (bool)Arr::pull($config, 'handle_error');
+            $handleFatal = (bool)Arr::pull($config, 'handle_fatal');
             Rollbar::init($config, $handleException, $handleError, $handleFatal);
 
             return Rollbar::logger();
@@ -58,7 +41,7 @@ class RollbarServiceProvider extends ServiceProvider
         $this->app->singleton(MonologHandler::class, function (Application $app) {
 
             $level = static::config('level', 'debug');
-            
+
             $handler = new MonologHandler($app[RollbarLogger::class], $level);
             $handler->setApp($app);
 
@@ -67,11 +50,30 @@ class RollbarServiceProvider extends ServiceProvider
     }
 
     /**
+     * Boot is called after all services are registered.
+     *
+     * This is where we can start listening for events.
+     *
+     * @param RollbarLogger $logger This parameter is injected by the service container, and is required to ensure that
+     *                              the Rollbar logger is initialized.
+     * @return void
+     *
+     * @since 8.1.0
+     */
+    public function boot(RollbarLogger $logger): void
+    {
+        // Set up telemetry if it is enabled.
+        if (null !== Rollbar::getTelemeter()) {
+            $this->setupTelemetry($this->getConfigs($this->app));
+        }
+    }
+
+    /**
      * Check if we should prevent the service from registering.
      *
      * @return boolean
      */
-    public function stop() : bool
+    public function stop(): bool
     {
         $level = static::config('level');
 
@@ -85,8 +87,8 @@ class RollbarServiceProvider extends ServiceProvider
     /**
      * Return a rollbar logging config.
      *
-     * @param string $key     The config key to lookup.
-     * @param mixed  $default The default value to return if the config is not found.
+     * @param string $key The config key to lookup.
+     * @param mixed $default The default value to return if the config is not found.
      *
      * @return mixed
      */
@@ -98,8 +100,66 @@ class RollbarServiceProvider extends ServiceProvider
             $envKey = 'ROLLBAR_TOKEN';
         }
 
-        $logKey = empty($key) ? 'logging.channels.rollbar' : "logging.channels.rollbar.$key";
+        $logKey = empty($key) ? 'logging.channels.rollbar' : 'logging.channels.rollbar.' . $key;
 
         return getenv($envKey) ?: Config::get($logKey, $default);
+    }
+
+    /**
+     * Returns the Rollbar configuration.
+     *
+     * @param Application $app The Laravel application.
+     * @return array
+     *
+     * @since 8.1.0
+     *
+     * @throw InvalidArgumentException If the Rollbar access token is not configured.
+     */
+    public function getConfigs(Application $app): array
+    {
+        $defaults = [
+            'environment' => $app->environment(),
+            'root' => base_path(),
+            'handle_exception' => true,
+            'handle_error' => true,
+            'handle_fatal' => true,
+        ];
+
+        $config = array_merge($defaults, $app['config']->get('logging.channels.rollbar', []));
+        $config['access_token'] = static::config('access_token');
+
+        if (empty($config['access_token'])) {
+            throw new InvalidArgumentException('Rollbar access token not configured');
+        }
+        // Convert a request for the Rollbar agent to handle the logs to
+        // the format expected by `Rollbar::init`.
+        // @see https://github.com/rollbar/rollbar-php-laravel/issues/85
+        $handler = Arr::get($config, 'handler', MonologHandler::class);
+        if ($handler === AgentHandler::class) {
+            $config['handler'] = 'agent';
+        }
+        $config['framework'] = 'laravel ' . $app->version();
+        return $config;
+    }
+
+    /**
+     * Sets up the telemetry event listeners.
+     *
+     * @param array $config
+     * @return void
+     *
+     * @since 8.1.0
+     */
+    protected function setupTelemetry(array $config): void
+    {
+        $this->telemetryListener = new TelemetryListener($this->app, $config);
+
+        try {
+            $dispatcher = $this->app->make(Dispatcher::class);
+        } catch (BindingResolutionException $e) {
+            return;
+        }
+
+        $this->telemetryListener->listen($dispatcher);
     }
 }

--- a/src/TelemetryListener.php
+++ b/src/TelemetryListener.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Rollbar\Laravel;
+
+use Exception;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Routing\Events\RouteMatched;
+use Rollbar\Rollbar;
+use Rollbar\Telemetry\EventType;
+use Rollbar\Telemetry\EventLevel;
+use Rollbar\Telemetry\Telemeter;
+
+/**
+ * This class handles Laravel events and maps them to Rollbar telemetry events.
+ *
+ * @since 8.1.0
+ */
+class TelemetryListener
+{
+    const BASE_EVENTS = [
+        MessageLogged::class => 'logMessageHandler',
+        RouteMatched::class => 'routeMatchedHandler',
+        QueryExecuted::class => 'queryExecutedHandler',
+    ];
+
+    private Container $container;
+
+    private array $config;
+
+    /**
+     * @var bool
+     */
+    private bool $captureLogs;
+    private bool $captureRouting;
+    private bool $captureQueries;
+    private bool $captureDbParameters;
+
+    /**
+     * @param Container $container The Laravel application container.
+     * @param array $config
+     */
+    public function __construct(Container $container, array $config)
+    {
+        $this->container = $container;
+        $this->config = $config;
+
+        $this->captureLogs = boolval($this->config['telemetry']['capture_logs'] ?? true);
+        $this->captureRouting = boolval($this->config['telemetry']['capture_routing'] ?? true);
+        $this->captureQueries = boolval($this->config['telemetry']['capture_db_queries'] ?? true);
+        // We do not want to capture query parameters by default, the developer must explicitly enable it.
+        $this->captureDbParameters = boolval($this->config['telemetry']['capture_db_query_parameters'] ?? false);
+    }
+
+    /**
+     * Register the event listeners for the application.
+     *
+     * @param Dispatcher $dispatcher
+     * @return void
+     */
+    public function listen(Dispatcher $dispatcher): void
+    {
+        foreach (self::BASE_EVENTS as $event => $handler) {
+            $dispatcher->listen($event, [$this, $handler]);
+        }
+    }
+
+    /**
+     * Execute the event handler.
+     *
+     * This is used so that the handlers are not public methods.
+     *
+     * @param string $method The method to call.
+     * @param array $args The arguments to pass to the method.
+     * @return void
+     */
+    public function __call(string $method, array $args): void
+    {
+        if (!method_exists($this, $method)) {
+            return;
+        }
+
+        try {
+            $this->{$method}(...$args);
+        } catch (Exception $e) {
+            // Do nothing.
+        }
+    }
+
+    /**
+     * Handler for log messages.
+     *
+     * @param MessageLogged $message
+     * @return void
+     */
+    protected function logMessageHandler(MessageLogged $message): void
+    {
+        if (null === $message->message || !$this->captureLogs) {
+            return;
+        }
+
+        Rollbar::captureTelemetryEvent(
+            EventType::Log,
+            // Telemetry does not support all PSR-3 or RFC-5424 levels, so we need to convert them.
+            Telemeter::getLevelFromPsrLevel($message->level),
+            array_merge(
+                $message->context,
+                ['message' => $message->message],
+            ),
+        );
+    }
+
+    protected function routeMatchedHandler(RouteMatched $matchedRoute): void
+    {
+        if (!$this->captureRouting) {
+            return;
+        }
+        $routePath = $matchedRoute->route->uri();
+
+        Rollbar::captureTelemetryEvent(
+            EventType::Manual,
+            EventLevel::Info,
+            [
+                'message' => 'Route matched',
+                'route' => $routePath,
+            ],
+        );
+    }
+
+    protected function queryExecutedHandler(QueryExecuted $query): void
+    {
+        if (!$this->captureQueries) {
+            return;
+        }
+
+        $meta = [
+            'message' => 'Query executed',
+            'query' => $query->sql,
+            'time' => $query->time,
+            'connection' => $query->connectionName,
+        ];
+
+        if ($this->captureDbParameters) {
+            $meta['bindings'] = $query->bindings;
+        }
+
+        Rollbar::captureTelemetryEvent(EventType::Manual, EventLevel::Info, $meta);
+    }
+}

--- a/tests/TelemetryListenerTest.php
+++ b/tests/TelemetryListenerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Rollbar\Laravel\Tests;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Http\Request;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Routing\Route;
+use Rollbar\Rollbar;
+use Rollbar\Telemetry\EventLevel;
+
+class TelemetryListenerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Rollbar::getTelemeter()?->clearQueue();
+    }
+
+    public function testTelemetryDisabled(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry' => false,
+        ]);
+
+        self::assertFalse($this->app['config']->get('logging.channels.rollbar.telemetry'));
+        self::assertNull(Rollbar::getTelemeter());
+    }
+
+    public function testTelemetryCapturesLaravelLogs(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry.capture_logs' => true,
+        ]);
+
+        self::assertTrue($this->app['config']->get('logging.channels.rollbar.telemetry.capture_logs'));
+
+        $this->app['events']->dispatch(new MessageLogged(
+            level: 'debug',
+            message: 'telemetry test message',
+            context: ['foo' => 'bar']
+        ));
+
+        $telemetryEvents = Rollbar::getTelemeter()->copyEvents();
+        $lastItem = array_pop($telemetryEvents);
+
+        self::assertSame(EventLevel::Debug, $lastItem->level);
+        self::assertSame('telemetry test message', $lastItem->body->message);
+        self::assertSame(['foo' => 'bar'], $lastItem->body->extra);
+    }
+
+    public function testTelemetryDoesNotCaptureLaravelLogsWhenDisabled(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry.capture_logs' => false,
+        ]);
+
+        self::assertFalse($this->app['config']->get('logging.channels.rollbar.telemetry.capture_logs'));
+
+        $this->app['events']->dispatch(new MessageLogged(
+            level: 'debug',
+            message: 'telemetry test message',
+            context: ['foo' => 'bar']
+        ));
+
+        self::assertEmpty(Rollbar::getTelemeter()->copyEvents());
+    }
+
+    public function testTelemetryCapturesRouteMatched(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry.capture_routing' => true,
+        ]);
+
+        self::assertTrue($this->app['config']->get('logging.channels.rollbar.telemetry.capture_routing'));
+
+        $this->app['events']->dispatch(new RouteMatched(
+            route: new Route(
+                methods: ['GET'],
+                uri: 'test',
+                action: (fn() => 'test')(...),
+            ),
+            request: new Request(),
+        ));
+
+        $telemetryEvents = Rollbar::getTelemeter()->copyEvents();
+        $lastItem = array_pop($telemetryEvents);
+
+        self::assertSame(EventLevel::Info, $lastItem->level);
+        self::assertSame('Route matched', $lastItem->body->message);
+        self::assertSame(['route' => 'test'], $lastItem->body->extra);
+    }
+
+    public function testTelemetryDoesNotCaptureRouteMatchedWhenDisabled(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry.capture_routing' => false,
+        ]);
+
+        self::assertFalse($this->app['config']->get('logging.channels.rollbar.telemetry.capture_routing'));
+
+        $this->app['events']->dispatch(new RouteMatched(
+            route: new Route(
+                methods: ['GET'],
+                uri: 'test',
+                action: (fn() => 'test')(...),
+            ),
+            request: new Request(),
+        ));
+
+        self::assertEmpty(Rollbar::getTelemeter()->copyEvents());
+    }
+
+    public function testTelemetryCapturesQueryExecuted(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry.capture_db_queries' => true,
+            'logging.channels.rollbar.telemetry.capture_db_query_parameters' => true,
+        ]);
+
+        self::assertTrue($this->app['config']->get('logging.channels.rollbar.telemetry.capture_db_queries'));
+        self::assertTrue($this->app['config']->get('logging.channels.rollbar.telemetry.capture_db_query_parameters'));
+
+        $this->app['events']->dispatch(new QueryExecuted(
+            sql: 'SELECT * FROM test WHERE id = ?',
+            bindings: [1],
+            time: 0.1,
+            connection: new Connection(
+                pdo: (fn() => 'test')(...),
+                config: ['name' => 'connection_name'],
+            ),
+        ));
+
+        $telemetryEvents = Rollbar::getTelemeter()->copyEvents();
+        $lastItem = array_pop($telemetryEvents);
+
+        self::assertSame(EventLevel::Info, $lastItem->level);
+        self::assertSame('Query executed', $lastItem->body->message);
+        self::assertSame([
+            'query' => 'SELECT * FROM test WHERE id = ?',
+            'time' => 0.1,
+            'connection' => 'connection_name',
+            'bindings' => [1],
+        ], $lastItem->body->extra);
+    }
+
+    public function testTelemetryDoesNotCaptureQueryExecutedWhenDisabled(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry.capture_db_queries' => false,
+        ]);
+
+        self::assertFalse($this->app['config']->get('logging.channels.rollbar.telemetry.capture_db_queries'));
+
+        $this->app['events']->dispatch(new QueryExecuted(
+            sql: 'SELECT * FROM test WHERE id = ?',
+            bindings: [1],
+            time: 0.1,
+            connection: new Connection(
+                pdo: (fn() => 'test')(...),
+                config: ['name' => 'connection_name'],
+            ),
+        ));
+
+        self::assertEmpty(Rollbar::getTelemeter()->copyEvents());
+    }
+
+    public function testTelemetryDoesNotCaptureQueryParametersWhenDisabled(): void
+    {
+        $this->refreshApplicationWithConfig([
+            'logging.channels.rollbar.telemetry.capture_db_queries' => true,
+            'logging.channels.rollbar.telemetry.capture_db_query_parameters' => false,
+        ]);
+
+        self::assertTrue($this->app['config']->get('logging.channels.rollbar.telemetry.capture_db_queries'));
+        self::assertFalse($this->app['config']->get('logging.channels.rollbar.telemetry.capture_db_query_parameters'));
+
+        $this->app['events']->dispatch(new QueryExecuted(
+            sql: 'SELECT * FROM test WHERE id = ?',
+            bindings: [1],
+            time: 0.1,
+            connection: new Connection(
+                pdo: (fn() => 'test')(...),
+                config: ['name' => 'connection_name'],
+            ),
+        ));
+
+        $telemetryEvents = Rollbar::getTelemeter()->copyEvents();
+        $lastItem = array_pop($telemetryEvents);
+
+        self::assertSame(EventLevel::Info, $lastItem->level);
+        self::assertSame('Query executed', $lastItem->body->message);
+        self::assertSame([
+            'query' => 'SELECT * FROM test WHERE id = ?',
+            'time' => 0.1,
+            'connection' => 'connection_name',
+        ], $lastItem->body->extra);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rollbar\Laravel\Tests;
+
+use Illuminate\Foundation\Application;
+use Mockery;
+use Rollbar\Laravel\RollbarServiceProvider;
+
+abstract class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected string $access_token = 'B42nHP04s06ov18Dv8X7VI4nVUs6w04X';
+
+    protected array $appConfig = [];
+
+    protected function setUp(): void
+    {
+        putenv('ROLLBAR_TOKEN=' . $this->access_token);
+
+        parent::setUp();
+
+        Mockery::close();
+    }
+
+    /**
+     * Set up the environment.
+     *
+     * @param $app
+     * @return void
+     */
+    protected function defineEnvironment($app): void
+    {
+        $configs = array_merge(
+            [
+                'logging.channels.rollbar.driver' => 'rollbar',
+                'logging.channels.rollbar.level' => 'debug',
+                'logging.channels.rollbar.access_token' => env('ROLLBAR_TOKEN'),
+            ],
+            $this->appConfig,
+        );
+        foreach ($configs as $key => $value) {
+            $app['config']->set($key, $value);
+        }
+    }
+
+    /**
+     * @param Application $app The Laravel application.
+     * @return class-string[] The service providers to register.
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [RollbarServiceProvider::class];
+    }
+
+    /**
+     * Creates a new Laravel application with the given configuration and sets it as the active application.
+     *
+     * @param array $config The configuration to use.
+     * @return void
+     */
+    protected function refreshApplicationWithConfig(array $config): void
+    {
+        $this->appConfig = $config;
+        $this->refreshApplication();
+    }
+}


### PR DESCRIPTION
## Description of the change

This PR adds support for telemetry to the Laravel package. There are a few notable items in this PR:

- This will be releases as a `beta` version since it depends on the Rollbar PHP core SDK `v4.1.0-rc`. Once the stable version of `v4.1` is released we will put out a stable release of this package.
- I updated how we handle configs to better support the additional configs for telemetry.
- The test suite was not being run in CI and needed some updates, in addition of telemetry tests.

This adds telemetry for three Laravel events to start with. We can add more as we see what is useful to the community. Each event type can be enabled or disabled individually. The events are:

- `MessageLogged`.
- `RouteMatched`.
- `QueryExecuted`.

The commit https://github.com/rollbar/rollbar-php-laravel/pull/160/commits/6a456ae4fe0b7678e12d9b3dee8a20cd24488ce6 message should have been "Added tests for telemetry." 🤦 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #42

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
