### PR TITLE
Added Laravel 11, PHP 8.3, and PHP 8.4 to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ jobs:
         os: [ubuntu]
         php: [8.4, 8.3, 8.2, 8.1]
         laravel: [^11, ^10]
-      exclude:
-        - php: 8.1
-          laravel: ^11
+
+        exclude:
+          - php: 8.1
+            laravel: ^11
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [8.2, 8.1]
-        laravel: [^10]
+        php: [8.4, 8.3, 8.2, 8.1]
+        laravel: [^11, ^10]
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         os: [ubuntu]
         php: [8.4, 8.3, 8.2, 8.1]
         laravel: [^11, ^10]
+      exclude:
+        - php: 8.1
+          laravel: ^11
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"
     name: Laravel ${{ matrix.laravel }} on PHP ${{ matrix.php }} (${{ matrix.os }})


### PR DESCRIPTION
## Description of the change

This PR adds Laravel 11, PHP 8.3, and PHP 8.4 to the CI test suite.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
