### PR TITLE
Fix Unresolvable dependency, Rollbar should not be started when there…

### DIFF
--- a/src/RollbarServiceProvider.php
+++ b/src/RollbarServiceProvider.php
@@ -54,14 +54,18 @@ class RollbarServiceProvider extends ServiceProvider
      *
      * This is where we can start listening for events.
      *
-     * @param RollbarLogger $logger This parameter is injected by the service container, and is required to ensure that
-     *                              the Rollbar logger is initialized.
      * @return void
      *
      * @since 8.1.0
      */
-    public function boot(RollbarLogger $logger): void
+    public function boot(): void
     {
+        if ($this->stop() === true) {
+            return;
+        }
+
+        //ensure that the Rollbar logger is initialized
+        app(RollbarLogger::class);
         // Set up telemetry if it is enabled.
         if (null !== Rollbar::getTelemeter()) {
             $this->setupTelemetry($this->getConfigs($this->app));


### PR DESCRIPTION
Solution for https://github.com/rollbar/rollbar-php-laravel/issues/168

## Description of the change

Rollbar cannot be initialized without key, this is a normal situation on development and test environments. Latest change broke this, 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- https://github.com/rollbar/rollbar-php-laravel/issues/168
- https://github.com/rollbar/rollbar-php-laravel/issues/167

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

