### PR TITLE
Fixed #171 Log context passed directly to telemetry body.

### DIFF
--- a/src/TelemetryListener.php
+++ b/src/TelemetryListener.php
@@ -105,10 +105,10 @@ class TelemetryListener
             EventType::Log,
             // Telemetry does not support all PSR-3 or RFC-5424 levels, so we need to convert them.
             Telemeter::getLevelFromPsrLevel($message->level),
-            array_merge(
-                $message->context,
-                ['message' => $message->message],
-            ),
+            [
+                'message' => $message->message,
+                'context' => $message->context,
+            ],
         );
     }
 

--- a/tests/TelemetryListenerTest.php
+++ b/tests/TelemetryListenerTest.php
@@ -49,7 +49,7 @@ class TelemetryListenerTest extends TestCase
 
         self::assertSame(EventLevel::Debug, $lastItem->level);
         self::assertSame('telemetry test message', $lastItem->body->message);
-        self::assertSame(['foo' => 'bar'], $lastItem->body->extra);
+        self::assertSame(['context' => ['foo' => 'bar']], $lastItem->body->extra);
     }
 
     public function testTelemetryDoesNotCaptureLaravelLogsWhenDisabled(): void


### PR DESCRIPTION
## Description of the change

This resolves a bug in how log context is passed to telemetry. It moves the context to a `context` key in the extra data in the telemetry body.

Without this context array keys that also match telemetry body defined keys could throw type errors if the types don't match.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix #171

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
