### PR TITLE
Added Laravel 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
         laravel: [dev-master, 13.x, 12.x, 11.x, 10.x]
 
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,24 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        php: [8.5 8.4, 8.3, 8.2, 8.1]
-        laravel: [dev-master, 11.x, 10.x]
+        php: [8.4, 8.3, 8.2, 8.1]
+        laravel: [dev-master, 13.x, 12.x, 11.x, 10.x]
 
         exclude:
+          # Laravel 11+ requires PHP 8.2+
           - php: 8.1
             laravel: dev-master
           - php: 8.1
+            laravel: 13.x
+          - php: 8.1
+            laravel: 12.x
+          - php: 8.1
             laravel: 11.x
+          # Laravel 13+ requires PHP 8.3+
+          - php: 8.2
+            laravel: dev-master
+          - php: 8.2
+            laravel: 13.x
             
     env:
       ROLLBAR_TOKEN: "ad865e76e7fb496fab096ac07b1dbabb"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Tests are in `tests`.
 * To run the tests: `composer test`
 * To fix code style issues: `composer fix`
 
+**Note:** The test suite uses [Orchestra Testbench](https://github.com/orchestral/testbench), which resolves the Laravel version based on your installed PHP. To reproduce Laravel 13-specific failures locally you need **PHP 8.3 or higher** — PHP 8.1/8.2 will resolve to Testbench 9/10 (Laravel 11/12) and will not exercise the Laravel 13 container. The full Laravel 13 integration is verified by CI, which runs the real Laravel install against PHP 8.3+.
+
 ## Docker
 Docker binaries are located in `./bin` and can be run by simply executing `bin/phpunit` for example.
 * To run tests: `bin/phpunit`

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "rollbar/rollbar": "^v4.1.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1",
         "php-coveralls/php-coveralls": "^2.2",
         "squizlabs/php_codesniffer": "3.*",
-        "phpunit/phpunit": "^8|^9.1"
+        "phpunit/phpunit": "^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="tests/bootstrap.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage processUncoveredFiles="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd">
+    <coverage>
         <include>
             <directory suffix=".php">./src</directory>
         </include>


### PR DESCRIPTION
## Description of the change

Adds Laravel 13 support to the master branch. Laravel 13 requires PHP 8.3+ and ships with PHPUnit 12. This change updates the dependency constraints in `composer.json`, modernizes `phpunit.xml` to be compatible with PHPUnit 10–12, expands the CI matrix to test against Laravel 12.x and 13.x, and documents the PHP 8.3 requirement for local Laravel 13 testing.

**Note:** This PR was largely generated with AI assistance and validated against a fresh Laravel 13 installation.

  Key changes:
  - `illuminate/support`: added `^13.0`
  - `orchestra/testbench`: expanded to `^8.0|^9.0|^10.0|^11.0` (covers Laravel 10–13)
  - `phpunit/phpunit`: updated from `^8|^9.1` to `^10.0|^11.0|^12.0` — PHPUnit 8/9
    were already non-installable in practice because testbench 8.x+ transitively
    requires PHPUnit 10+
  - `phpunit.xml`: removed deprecated PHPUnit 9 attributes (`backupStaticAttributes`,
    `convertErrorsToExceptions`, `convertNoticesToExceptions`,
    `convertWarningsToExceptions`, `processIsolation`, `stopOnFailure`); updated
    schema to `10.0` and reverted to the `<coverage><include>` structure compatible
    with PHPUnit 10 and 11 (PHPUnit 12 will accept this with a deprecation notice
    until PHP 8.1/8.2 support is dropped)
  - CI matrix: added `12.x` and `13.x` Laravel targets; added exclusions for
    PHP 8.1 with Laravel 12/13 and PHP 8.2 with Laravel 13/dev-master; removed PHP
    8.5 (runner availability not confirmed); fixed a pre-existing typo (`8.5 8.4`
    missing comma)
  - README: noted that PHP 8.3+ is required locally to exercise the Laravel 13
    Testbench container

  No source code changes were required — the existing service provider, handlers,
  and telemetry listener APIs are all compatible with Laravel 13.

  ## Type of change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Maintenance
  - [ ] New release

  ## Related issues

  - Fix [SDK-586](https://linear.app/rollbar-inc/issue/SDK-586/laravel-13-support)

  ## Checklists

  ### Development

  - [ ] Lint rules pass locally
  - [ ] The code changed/added as part of this pull request has been covered with tests
  - [ ] All tests related to the changed code pass in development

  ### Code review

  - [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
  - [ ] "Ready for review" label attached to the PR and reviewers assigned
  - [ ] Issue from task tracker has a link to this pull request
  - [ ] Changes have been reviewed by at least one other engineer