### PR TITLE
Fixed failing PHPUnit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ composer.lock
 .DS_Store
 .idea
 .vscode
-.phpunit.result.cache
+.phpunit.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
     </coverage>
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         colors="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd">
-    <coverage>
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <source restrictNotices="true" restrictWarnings="true">
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests/</directory>

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -6,7 +6,7 @@ use Illuminate\Foundation\Application;
 use Mockery;
 use Rollbar\Laravel\RollbarServiceProvider;
 
-abstract class TestCase extends \Orchestra\Testbench\TestCase
+abstract class AbstractTestCase extends \Orchestra\Testbench\TestCase
 {
     protected string $access_token = 'B42nHP04s06ov18Dv8X7VI4nVUs6w04X';
 

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -6,7 +6,7 @@ use Rollbar\Laravel\MonologHandler;
 use Rollbar\Laravel\AgentHandler;
 use Rollbar\RollbarLogger;
 
-class RollbarTest extends TestCase
+class RollbarTest extends AbstractTestCase
 {
     public function testBinding()
     {

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -2,10 +2,18 @@
 
 namespace Rollbar\Laravel\Tests;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use Rollbar\Laravel\MonologHandler;
 use Rollbar\Laravel\AgentHandler;
+use Rollbar\Laravel\RollbarServiceProvider;
+use Rollbar\Laravel\TelemetryListener;
 use Rollbar\RollbarLogger;
 
+#[UsesClass(AgentHandler::class)]
+#[UsesClass(MonologHandler::class)]
+#[UsesClass(TelemetryListener::class)]
+#[CoversClass(RollbarServiceProvider::class)]
 class RollbarTest extends AbstractTestCase
 {
     public function testBinding()

--- a/tests/TelemetryListenerTest.php
+++ b/tests/TelemetryListenerTest.php
@@ -11,7 +11,7 @@ use Illuminate\Routing\Route;
 use Rollbar\Rollbar;
 use Rollbar\Telemetry\EventLevel;
 
-class TelemetryListenerTest extends TestCase
+class TelemetryListenerTest extends AbstractTestCase
 {
     protected function setUp(): void
     {

--- a/tests/TelemetryListenerTest.php
+++ b/tests/TelemetryListenerTest.php
@@ -8,9 +8,15 @@ use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use Rollbar\Laravel\RollbarServiceProvider;
+use Rollbar\Laravel\TelemetryListener;
 use Rollbar\Rollbar;
 use Rollbar\Telemetry\EventLevel;
 
+#[UsesClass(RollbarServiceProvider::class)]
+#[CoversClass(TelemetryListener::class)]
 class TelemetryListenerTest extends AbstractTestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
## Description of the change

PHPUnit 9 ignored abstract classes that matched test classes in the test suite. Starting in PHPUnit 10 that is no longer the case. This PR resolves an issue where PHPUnit complained even though the test suite ran successfully.

This also resolves some issues around code coverage and the `phpunit.xml` schema.

## Type of change

- [x] Maintenance

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
